### PR TITLE
Prevent menu from echoing escape sequences

### DIFF
--- a/spells/cantrips/await-keypress
+++ b/spells/cantrips/await-keypress
@@ -25,6 +25,7 @@ fi
 
 TTY_DEVICE=${AWAIT_KEYPRESS_DEVICE:-/dev/tty}
 skip_stty=${AWAIT_KEYPRESS_SKIP_STTY:-0}
+keep_raw=${AWAIT_KEYPRESS_KEEP_RAW:-0}
 
 if [ "$skip_stty" -eq 1 ]; then
     # Allow tests to provide a preconfigured file descriptor instead of
@@ -115,7 +116,11 @@ while :; do
 done
 
 trap - EXIT
-restore
+if [ "$skip_stty" -eq 0 ] && [ "$keep_raw" -eq 1 ]; then
+    exec 3>&- 2>/dev/null || :
+else
+    restore
+fi
 
 # Translate byte sequences into human-friendly key names.
 case "$first_codes" in

--- a/spells/cantrips/menu
+++ b/spells/cantrips/menu
@@ -45,6 +45,30 @@ require fathom-terminal "The menu spell needs 'fathom-terminal' to measure the s
 require move-cursor "The menu spell needs 'move-cursor' to reposition the cursor." || exit 1
 require await-keypress "The menu spell needs 'await-keypress' to read input." || exit 1
 require cursor-blink "The menu spell needs 'cursor-blink' to restore the cursor." || exit 1
+require stty "The menu spell needs 'stty' to manage terminal modes." || exit 1
+
+menu_tty=${AWAIT_KEYPRESS_DEVICE:-/dev/tty}
+if [ ! -r "$menu_tty" ] || [ ! -w "$menu_tty" ]; then
+        printf '%s\n' "menu: unable to access controlling terminal '$menu_tty'" >&2
+        exit 1
+fi
+
+if ! menu_saved_tty_state=$(stty -g <"$menu_tty" 2>/dev/null); then
+        printf '%s\n' 'menu: unable to read terminal settings' >&2
+        exit 1
+fi
+
+terminal_restored=0
+restore_terminal() {
+        if [ "$terminal_restored" -eq 1 ]; then
+                return
+        fi
+        terminal_restored=1
+        stty "$menu_saved_tty_state" <"$menu_tty" >/dev/null 2>&1 || :
+}
+
+AWAIT_KEYPRESS_KEEP_RAW=1
+export AWAIT_KEYPRESS_KEEP_RAW
 
 # Load colour helpers when present; otherwise fall back to plain text.
 if [ -r "$script_dir/colors" ]; then
@@ -82,6 +106,7 @@ cleanup() {
                 return
         fi
         cleanup_called=1
+        restore_terminal
         cursor-blink on >/dev/null 2>&1 || :
         rm -f "$items_file" "$commands_file"
 }


### PR DESCRIPTION
## Summary
- add a persistent-raw-mode option to `await-keypress` so callers can keep the terminal in raw mode between reads
- have the menu spell capture and restore terminal settings while keeping `await-keypress` in raw mode to avoid stray escape codes

## Testing
- not run (bats unavailable in the environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69187a5d05108320b8251380df49787a)