### PR TITLE
Silence menu exit messages

### DIFF
--- a/spells/menu/install-menu
+++ b/spells/menu/install-menu
@@ -31,8 +31,8 @@ if ! require menu "The install-menu spell needs the 'menu' command to present ch
     exit 1
 fi
 
-# Let the user bail out with Ctrl+C while still printing a friendly message.
-trap 'printf "\nExiting install menu.\n" >&2; exit 0' INT
+# Let the user bail out with Ctrl+C without emitting extra output.
+trap 'exit 0' INT
 
 launch_submenu() {
     printf '\n'

--- a/spells/menu/system-menu
+++ b/spells/menu/system-menu
@@ -55,7 +55,7 @@ display_menu() {
 }
 
 handle_ctrl_c() {
-  trap 'echo exiting; exit' INT
+  trap 'exit 0' INT
 }
 
 handle_ctrl_c


### PR DESCRIPTION
## Summary
- remove exit-message traps from system and install menus so exiting stays silent
- keep Ctrl+C handling while avoiding extra output when leaving the menus

## Testing
- bats tests/test_menu_spells.bats *(fails: bats not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919b210f4f48320ad3cf22b10067fe2)