### PR TITLE
Enable bubblewrap user namespaces in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install bubblewrap dependency
-        run: sudo apt-get update && sudo apt-get install -y bubblewrap
+        run: sudo apt-get update && sudo apt-get install -y bubblewrap uidmap
+      - name: Configure bubblewrap user namespaces
+        run: |
+          sudo usermod --add-subuids 100000-165535 --add-subgids 100000-165535 "$(whoami)"
+          echo 'kernel.unprivileged_userns_clone=1' | sudo tee /etc/sysctl.d/99-unprivileged-userns.conf
+          sudo sysctl --system
+      - name: Verify bubblewrap setup
+        run: bwrap --unshare-user-try --ro-bind / / /bin/true
       - name: Run unit tests
         run: ./spells/menu/system/run-tests
       - name: Report coverage

--- a/spells/menu/system/run-tests
+++ b/spells/menu/system/run-tests
@@ -121,12 +121,26 @@ if [ "$list_only" -eq 1 ]; then
 fi
 
 status=0
+pass_scripts=0
+fail_scripts=0
 for test in "${test_files[@]}"; do
   echo "Running ${test#"$ROOT_DIR/"}"
   if ! sh "$test"; then
     status=1
+    fail_scripts=$((fail_scripts + 1))
+  else
+    pass_scripts=$((pass_scripts + 1))
   fi
   echo
 done
+
+total_scripts=$((pass_scripts + fail_scripts))
+if [ "$total_scripts" -gt 0 ]; then
+  if [ "$fail_scripts" -gt 0 ]; then
+    echo "Test summary: $fail_scripts failed, $pass_scripts passed ($total_scripts total)"
+  else
+    echo "Test summary: all $pass_scripts test scripts passed"
+  fi
+fi
 
 exit $status


### PR DESCRIPTION
## Summary
- add subuid/subgid ranges and enable unprivileged user namespaces so bubblewrap works in GitHub Actions
- keep the bubblewrap verification step ahead of the test suite

## Testing
- ./spells/menu/system/run-tests --only test_bind-tome.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f1217e4a48320bd3492796be3fb25)