### PR TITLE
Improve bubblewrap setup reliability

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,28 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install bubblewrap dependency
-        run: sudo apt-get update && sudo apt-get install -y bubblewrap
+        run: sudo apt-get update && sudo apt-get install -y bubblewrap uidmap
+      - name: Configure bubblewrap user namespaces
+        run: |
+          sudo usermod --add-subuids 100000-165535 --add-subgids 100000-165535 "$(whoami)"
+          sudo usermod --add-subuids 100000-165535 --add-subgids 100000-165535 root
+          {
+            echo 'kernel.unprivileged_userns_clone=1'
+            echo 'kernel.apparmor_restrict_unprivileged_userns=0'
+          } | sudo tee /etc/sysctl.d/99-unprivileged-userns.conf
+          sudo sysctl --system
+      - name: Verify bubblewrap setup
+        run: |
+          if bwrap --unshare-user-try --ro-bind / / /bin/true; then
+            echo "bubblewrap usable with user namespaces"
+          elif sudo -n bwrap --unshare-user-try --ro-bind / / /bin/true; then
+            echo "bubblewrap usable via sudo with user namespaces"
+          elif sudo -n bwrap --ro-bind / / /bin/true; then
+            echo "bubblewrap usable via sudo"
+          else
+            echo "bubblewrap unusable" >&2
+            exit 1
+          fi
       - name: Run unit tests
         run: ./spells/menu/system/run-tests
       - name: Report coverage

--- a/spells/menu/system/run-tests
+++ b/spells/menu/system/run-tests
@@ -121,12 +121,26 @@ if [ "$list_only" -eq 1 ]; then
 fi
 
 status=0
+pass_scripts=0
+fail_scripts=0
 for test in "${test_files[@]}"; do
   echo "Running ${test#"$ROOT_DIR/"}"
   if ! sh "$test"; then
     status=1
+    fail_scripts=$((fail_scripts + 1))
+  else
+    pass_scripts=$((pass_scripts + 1))
   fi
   echo
 done
+
+total_scripts=$((pass_scripts + fail_scripts))
+if [ "$total_scripts" -gt 0 ]; then
+  if [ "$fail_scripts" -gt 0 ]; then
+    echo "Test summary: $fail_scripts failed, $pass_scripts passed ($total_scripts total)"
+  else
+    echo "Test summary: all $pass_scripts test scripts passed"
+  fi
+fi
 
 exit $status

--- a/tests/lib/test_common.sh
+++ b/tests/lib/test_common.sh
@@ -24,10 +24,25 @@ export PATH
 export WIZARDRY_TMPDIR
 
 BWRAP_AVAILABLE=1
+BWRAP_VIA_SUDO=0
+BWRAP_USE_UNSHARE=1
+
 if ! command -v bwrap >/dev/null 2>&1; then
   BWRAP_AVAILABLE=0
   BWRAP_REASON="bubblewrap not installed"
-elif ! bwrap --unshare-user-try --ro-bind / / /bin/true 2>/dev/null; then
+elif bwrap --unshare-user-try --ro-bind / / /bin/true 2>/dev/null; then
+  :
+elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+  if sudo -n bwrap --unshare-user-try --ro-bind / / /bin/true 2>/dev/null; then
+    BWRAP_VIA_SUDO=1
+  elif sudo -n bwrap --ro-bind / / /bin/true 2>/dev/null; then
+    BWRAP_VIA_SUDO=1
+    BWRAP_USE_UNSHARE=0
+  else
+    BWRAP_AVAILABLE=0
+    BWRAP_REASON="bubblewrap unusable even via sudo"
+  fi
+else
   BWRAP_AVAILABLE=0
   BWRAP_REASON="bubblewrap unusable (user namespaces likely disabled)"
 fi
@@ -35,6 +50,14 @@ fi
 if [ "$BWRAP_AVAILABLE" -eq 0 ]; then
   printf '%s\n' "WARNING: proceeding without bubblewrap sandbox: $BWRAP_REASON" >&2
 fi
+
+run_bwrap() {
+  if [ "$BWRAP_VIA_SUDO" -eq 1 ]; then
+    sudo -n bwrap "$@"
+  else
+    bwrap "$@"
+  fi
+}
 
 _pass_count=0
 _fail_count=0
@@ -94,9 +117,8 @@ run_cmd() {
   mkdir -p "$tmpdir" "$homedir"
 
   if [ "$BWRAP_AVAILABLE" -eq 1 ]; then
-    if bwrap \
+    set -- \
       --die-with-parent \
-      --unshare-user-try \
       --ro-bind / / \
       --dev-bind /dev /dev \
       --bind /proc /proc \
@@ -108,8 +130,13 @@ run_cmd() {
       --setenv HOME "$homedir" \
       --setenv TMPDIR "$tmpdir" \
       --setenv WIZARDRY_TMPDIR "$WIZARDRY_TMPDIR" \
-      -- "$@" \
-      >"$__stdout" 2>"$__stderr"; then
+      -- "$@"
+
+    if [ "$BWRAP_USE_UNSHARE" -eq 1 ]; then
+      set -- --unshare-user-try "$@"
+    fi
+
+    if run_bwrap "$@" >"$__stdout" 2>"$__stderr"; then
       STATUS=0
     else
       STATUS=$?


### PR DESCRIPTION
## Summary
- enable kernel tunables and subordinate ID ranges for both the runner user and root to support bubblewrap
- verify bubblewrap using sudo-based user namespaces before falling back to non-userns execution
- expand test helper bubblewrap detection to mirror sudo user-namespace attempts

## Testing
- ./spells/menu/system/run-tests --only test_bind-tome.sh


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f1217e4a48320bd3492796be3fb25)