### PR TITLE
Expand tome tests and track subtest totals

### DIFF
--- a/spells/menu/system/run-tests
+++ b/spells/menu/system/run-tests
@@ -269,6 +269,27 @@ fi
 status=0
 pass_scripts=0
 fail_scripts=0
+subtests_passed=0
+subtests_total=0
+
+record_subtests() {
+  local log=$1
+  if [[ $log =~ ([0-9]+)/([0-9]+)\ tests\ passed ]]; then
+    local passed=${BASH_REMATCH[1]}
+    local total=${BASH_REMATCH[2]}
+    subtests_passed=$((subtests_passed + passed))
+    subtests_total=$((subtests_total + total))
+    return
+  fi
+
+  if [[ $log =~ ([0-9]+)/([0-9]+)\ tests\ failed,\ ([0-9]+)\ passed ]]; then
+    local total=${BASH_REMATCH[2]}
+    local passed=${BASH_REMATCH[3]}
+    subtests_passed=$((subtests_passed + passed))
+    subtests_total=$((subtests_total + total))
+  fi
+}
+
 # Execute each test script, indenting its output for readability and
 # tallying pass/fail counts per script (not per individual assertion).
 for test in "${test_files[@]}"; do
@@ -276,10 +297,12 @@ for test in "${test_files[@]}"; do
   printf '%sRunning %s%s\n' "$BOLD" "$rel_path" "$RESET"
   if output=$(sh "$test" 2>&1); then
     pass_scripts=$((pass_scripts + 1))
+    record_subtests "$output"
     printf '%s\n' "$output" | sed 's/^/  /'
   else
     status=1
     fail_scripts=$((fail_scripts + 1))
+    record_subtests "$output"
     printf '%s\n' "$output" | sed 's/^/  /'
   fi
 done
@@ -291,10 +314,11 @@ scan_coverage
 
 total_scripts=$((pass_scripts + fail_scripts))
 coverage_uncovered=$((coverage_total - coverage_covered))
-printf 'Test summary: %s%d passed%s, %s%d failed%s, %s%d uncovered%s\n' \
+printf 'Test summary: %s%d passed%s, %s%d failed%s, %s%d uncovered%s, subtests %s%d/%d%s\n' \
   "$GREEN" "$pass_scripts" "$RESET" \
   "$RED" "$fail_scripts" "$RESET" \
-  "$YELLOW" "$coverage_uncovered" "$RESET"
+  "$YELLOW" "$coverage_uncovered" "$RESET" \
+  "$GREEN" "$subtests_passed" "$subtests_total" "$RESET"
 if [ "$coverage_uncovered" -gt 0 ]; then
   for spell in "${uncovered_spells[@]}"; do
     printf '  - %s%s%s\n' "$YELLOW" "$spell" "$RESET"

--- a/tests/test_unbind-tome.sh
+++ b/tests/test_unbind-tome.sh
@@ -2,15 +2,34 @@
 # Behavioral cases (derived from --help):
 # - unbind-tome requires a file argument
 # - unbind-tome splits the tome into sanitised files
+# - unbind-tome prints helpful usage text
+# - unbind-tome refuses non-file inputs and existing destination folders
+# - unbind-tome invents names for blank pages
 
 set -eu
 
 . "$(dirname "$0")/lib/test_common.sh"
 
+unbind_shows_usage() {
+  run_spell "spells/unbind-tome" --help
+  assert_success || return 1
+  assert_output_contains "Usage: unbind-tome" || return 1
+  assert_output_contains "Split a bound tome" || return 1
+}
+
 require_arg_for_unbind() {
   run_spell "spells/unbind-tome"
   assert_failure || return 1
   assert_error_contains "Error: Please provide a file path as an argument." || return 1
+}
+
+unbind_requires_a_file() {
+  tmpdir=$(make_tempdir)
+  mkdir -p "$tmpdir/dir"
+
+  run_spell "spells/unbind-tome" "$tmpdir/dir"
+  assert_failure || return 1
+  assert_error_contains "is not a file" || return 1
 }
 
 unbind_splits_into_pages() {
@@ -34,7 +53,43 @@ STORY
   assert_path_exists "$pieces_dir/Trailing_space" || return 1
 }
 
+unbind_avoids_clobbering_existing_folder() {
+  workdir=$(make_tempdir)
+  mkdir -p "$workdir/story" "$workdir/story1"
+  printf 'First\nSecond\n' >"$workdir/story.txt"
+
+  oldpwd=$(pwd)
+  cd "$workdir"
+  run_spell "spells/unbind-tome" "story.txt"
+  cd "$oldpwd"
+  assert_success || return 1
+
+  assert_path_exists "$workdir/story2" || return 1
+  assert_path_exists "$workdir/story2/First" || return 1
+  assert_path_exists "$workdir/story2/Second" || return 1
+}
+
+unbind_names_blank_pages() {
+  workdir=$(make_tempdir)
+  cat <<'STORY' >"$workdir/blanky.txt"
+
+Titled page
+
+STORY
+
+  RUN_CMD_WORKDIR="$workdir" run_spell "spells/unbind-tome" "$workdir/blanky.txt"
+  assert_success || return 1
+
+  assert_path_exists "$workdir/blanky/page_1" || return 1
+  assert_path_exists "$workdir/blanky/Titled_page" || return 1
+  assert_path_exists "$workdir/blanky/page_3" || return 1
+}
+
 run_test_case "unbind-tome requires a file argument" require_arg_for_unbind
 run_test_case "unbind-tome splits the tome into sanitised files" unbind_splits_into_pages
+run_test_case "unbind-tome shows usage text" unbind_shows_usage
+run_test_case "unbind-tome refuses non-file inputs" unbind_requires_a_file
+run_test_case "unbind-tome avoids clobbering existing folders" unbind_avoids_clobbering_existing_folder
+run_test_case "unbind-tome invents names for blank pages" unbind_names_blank_pages
 
 finish_tests


### PR DESCRIPTION
## Summary
- add additional subtests for bind-tome and unbind-tome including usage, invalid inputs, and collision handling
- record aggregate subtest pass/total counts in the run-tests summary output

## Testing
- spells/menu/system/run-tests


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69204d9af19083208ad3392ac6b05673)