### PR TITLE
Expand cross-platform test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,8 @@ on:
   pull_request:
 
 jobs:
-  tests:
+  ubuntu:
+    name: Tests (Ubuntu)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -29,6 +30,81 @@ jobs:
             echo "bubblewrap usable via sudo with user namespaces"
           elif sudo -n bwrap --ro-bind / / /bin/true; then
             echo "bubblewrap usable via sudo"
+          else
+            echo "bubblewrap unusable" >&2
+            exit 1
+          fi
+      - name: Run unit tests
+        run: ./spells/menu/system/test-magic --verbose
+
+  macos:
+    name: Tests (macOS)
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run unit tests
+        run: ./spells/menu/system/test-magic --verbose
+
+  debian:
+    name: Tests (Debian)
+    runs-on: ubuntu-latest
+    container: debian:stable-slim
+    steps:
+      - name: Install git for checkout
+        run: apt-get update && apt-get install -y git
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install bubblewrap dependency
+        run: apt-get update && apt-get install -y bubblewrap uidmap sudo
+      - name: Configure bubblewrap user namespaces
+        run: |
+          usermod --add-subuids 100000-165535 --add-subgids 100000-165535 "$(whoami)"
+          usermod --add-subuids 100000-165535 --add-subgids 100000-165535 root
+          {
+            echo 'kernel.unprivileged_userns_clone=1'
+            echo 'kernel.apparmor_restrict_unprivileged_userns=0'
+          } | tee /etc/sysctl.d/99-unprivileged-userns.conf
+          sysctl --system || true
+      - name: Verify bubblewrap setup
+        run: |
+          if bwrap --unshare-user-try --ro-bind / / /bin/true; then
+            echo "bubblewrap usable with user namespaces"
+          elif bwrap --ro-bind / / /bin/true 2>/dev/null; then
+            echo "bubblewrap usable via privileged execution"
+          else
+            echo "bubblewrap unusable" >&2
+            exit 1
+          fi
+      - name: Run unit tests
+        run: ./spells/menu/system/test-magic --verbose
+
+  arch:
+    name: Tests (Arch Linux)
+    runs-on: ubuntu-latest
+    container: archlinux:latest
+    steps:
+      - name: Install git for checkout
+        run: pacman -Sy --noconfirm git
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install test dependencies
+        run: pacman -Syu --noconfirm bubblewrap sudo shadow
+      - name: Configure bubblewrap user namespaces
+        run: |
+          usermod --add-subuids 100000-165535 --add-subgids 100000-165535 "$(whoami)"
+          usermod --add-subuids 100000-165535 --add-subgids 100000-165535 root
+          {
+            echo 'kernel.unprivileged_userns_clone=1'
+            echo 'kernel.apparmor_restrict_unprivileged_userns=0'
+          } | tee /etc/sysctl.d/99-unprivileged-userns.conf
+          sysctl --system || true
+      - name: Verify bubblewrap setup
+        run: |
+          if bwrap --unshare-user-try --ro-bind / / /bin/true; then
+            echo "bubblewrap usable with user namespaces"
+          elif bwrap --ro-bind / / /bin/true 2>/dev/null; then
+            echo "bubblewrap usable via privileged execution"
           else
             echo "bubblewrap unusable" >&2
             exit 1


### PR DESCRIPTION
## Summary
- add a Debian container job so Linux coverage includes both Ubuntu and Debian targets
- configure Arch container jobs to provision subuids/subgids and verify bubblewrap usability before running tests
- clarify that Android is not available on GitHub-hosted runners while keeping macOS coverage unchanged

## Testing
- Not run (CI-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921f678ece88320b2fb7b54603fa11f)