### PR TITLE
Handle attr past tense output

### DIFF
--- a/spells/divination/read-magic
+++ b/spells/divination/read-magic
@@ -34,7 +34,7 @@ file_exists() {
 }
 
 parse_attr_output() {
-  printf '%s\n' "$1" | sed 's/.*:[[:space:]]*//' | tail -n 1
+  printf '%s\n' "$1" | sed 's/.*:[[:space:]]*//' | awk 'NF {last = $0} END {print last}'
 }
 
 helper_usable() {

--- a/tests/divination/test_read-magic.sh
+++ b/tests/divination/test_read-magic.sh
@@ -62,20 +62,20 @@ case "$1" in
   -l)
     printf '%s\n' "user.alpha" "user.beta"
     ;;
-  -g)
-    case "$2" in
-      user.alpha)
-        printf 'Attribute "user.alpha" had a 10 byte value for /tmp/example:\n'
-        printf 'alpha-value\n'
-        ;;
-      user.beta)
-        printf 'Attribute "user.beta" had a 9 byte value for /tmp/example:\n'
-        printf 'beta-value\n'
-        ;;
-      *)
-        exit 1
-        ;;
-    esac
+      -g)
+        case "$2" in
+          user.alpha)
+            printf 'Attribute "user.alpha" had a 10 byte value for /tmp/example:\n'
+            printf 'alpha-value\n'
+            ;;
+          user.beta)
+            printf 'Attribute "user.beta" had a 9 byte value for /tmp/example:\n'
+            printf 'beta-value\n\n'
+            ;;
+          *)
+            exit 1
+            ;;
+        esac
     ;;
   *)
     exit 1


### PR DESCRIPTION
## Summary
- strip attr output using the final colon to support alternate formats
- update read-magic attr stub test to cover past-tense output

## Testing
- sh tests/divination/test_read-magic.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922fb64bf688320984ecadaff07bfc9)