### PR TITLE
Propagate test helper flag into bubblewrap sandbox

### DIFF
--- a/tests/test_common.sh
+++ b/tests/test_common.sh
@@ -187,7 +187,7 @@ run_cmd() {
       STATUS=$?
     fi
   else
-    if (cd "$workdir" && env PATH="$PATH" HOME="$homedir" TMPDIR="$tmpdir" WIZARDRY_TMPDIR="$WIZARDRY_TMPDIR" "$@" \
+    if (cd "$workdir" && env PATH="$PATH" HOME="$homedir" TMPDIR="$tmpdir" WIZARDRY_TMPDIR="$WIZARDRY_TMPDIR" WIZARDRY_TEST_HELPERS_ONLY="${WIZARDRY_TEST_HELPERS_ONLY-}" "$@" \
       >"$__stdout" 2>"$__stderr"); then
       STATUS=0
     else


### PR DESCRIPTION
## Summary
- ensure WIZARDRY_TEST_HELPERS_ONLY is passed into the bubblewrap sandbox so tests consistently rely on stub helpers

## Testing
- sh tests/divination/test_read-magic.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923a5b759e883208109fbde1a88f649)