### PR TITLE
Hardened license to v1.1

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,20 +1,21 @@
- ,___,   OPEN WIZARDRY LICENSE 1.0
+ ,___,   OPEN WIZARDRY LICENSE 1.1
  (O,O)
  /)  )   Permission: You may use, copy, modify, and share this project
 ="=="=   for non-commercial purposes, including private, educational,
          research, and internal organizational use.
 
-Commercial Use: Commercial exploitation is prohibited. "Commercial exploitation"
-means sale, subscription, paid access, monetized hosting, or inclusion in any
-paid product or service. Internal use by commercial entities is allowed.
+Commercial Use: Commercial exploitation is prohibited. “Commercial exploitation”
+means sale, subscription, paid access, monetized hosting, inclusion in any paid
+product or service, or use as part of any monetized system, even if not the
+primary component. Internal use by commercial entities is allowed.
 
 Reciprocity: If you make modified versions publicly available—either by
-distributing copies or by operating a public-facing service that relies on those
-modified files—you must publish those modified files under this license. No
-other files must be published.
+distributing copies or by operating a public-facing service that meaningfully
+depends on those modified files—you must publish those modified files under
+this license. No other files must be published.
 
-No Enclosure: You may not apply more restrictive terms to this project or to
-modified files you share. This license must accompany any public distribution of
-modified files.
+No Enclosure: Modified files you share must remain exclusively under this
+license, without additional restrictions. This license must accompany any public
+distribution of modified files.
 
 Warranty: Provided without warranty or guarantee of any kind.


### PR DESCRIPTION
Updated the Open Wizardry License from version 1.0 to 1.1 with clarifications on commercial use and reciprocity.