### PR TITLE
Enhance bitcoin arcanum installer and menu

### DIFF
--- a/spells/install/bitcoin/bitcoin-menu
+++ b/spells/install/bitcoin/bitcoin-menu
@@ -11,43 +11,96 @@ case "${1-}" in
 esac
 
 set -eu
-. colors
+
+load_colors() {
+  if command -v colors >/dev/null 2>&1; then
+    # shellcheck source=/dev/null
+    . colors
+  else
+    BOLD=""
+    CYAN=""
+    RESET=""
+  fi
+}
+
+load_colors
 
 # Catch Ctrl-C and TERM signal to exit cleanly
 trap 'exit 0' INT TERM
 
+wallet_balance_cmd=$(cat <<'CMD'
+Check Wallet Balance%sh -c 'printf "Wallet (leave blank for default): "; read -r w; cmd="bitcoin-cli"; [ -n "$w" ] && cmd="$cmd -rpcwallet=$w"; $cmd getbalance'
+CMD
+)
+
+new_address_cmd=$(cat <<'CMD'
+Get New Receive Address%sh -c 'printf "Wallet (leave blank for default): "; read -r w; cmd="bitcoin-cli"; [ -n "$w" ] && cmd="$cmd -rpcwallet=$w"; $cmd getnewaddress'
+CMD
+)
+
+send_coins_cmd=$(cat <<'CMD'
+Send Bitcoin%sh -c 'printf "Wallet (leave blank for default): "; read -r w; printf "Destination address: "; read -r addr; printf "Amount (BTC): "; read -r amt; cmd="bitcoin-cli"; [ -n "$w" ] && cmd="$cmd -rpcwallet=$w"; $cmd sendtoaddress "$addr" "$amt"'
+CMD
+)
+
+wallet_list_cmd="List Loaded Wallets%bitcoin-cli listwallets"
+wallet_dir_cmd="List Wallet Directory%bitcoin-cli listwalletdir"
+node_info_cmd="Node Overview%bitcoin-cli -getinfo"
+sync_status_cmd="Sync Progress%bitcoin-cli getblockchaininfo"
+peer_info_cmd="Peers%bitcoin-cli getpeerinfo"
+recent_tx_cmd="Recent Transactions%bitcoin-cli listtransactions '*' 10"
+
+start_daemon_cmd="Start bitcoind%bitcoind -daemon"
+stop_daemon_cmd="Stop bitcoind%bitcoin-cli stop"
+
+configure_cmd="Configure bitcoin.conf%configure-bitcoin"
+change_directory_cmd="Change Bitcoin Directory%change-bitcoin-directory"
+repair_permissions_cmd="Repair Permissions%repair-bitcoin-permissions"
+install_wizard_cmd="Install or Upgrade Bitcoin%install-bitcoin"
+
 # Displays the menu
 display_menu() {
-  title="${BOLD}${CYAN}Bitcoin: $(bitcoin-status)"
-  blockchain_info="Display Blockchain Info%bitcoin-cli getblockchaininfo"
-  set_config="Configure Bitcoin%configure-bitcoin"
-  change_directory="Change Bitcoin Directory%change-bitcoin-directory"
-  clear_cache="Clear Bitcoin Cache%# coming soon"
-  repair_permissions="Repair Permissions%repair-bitcoin-permissions"
+  status_label=$(bitcoin-status 2>/dev/null || echo "status unavailable")
+  title="${BOLD}${CYAN}Bitcoin: ${status_label}${RESET}"
   exit_label=$(exit-label)
   exit_option="${exit_label}%kill -TERM \$PPID"
-  
+
+  entries=""
   if is-bitcoin-installed; then
-    install_bitcoin_option="Uninstall Bitcoin%uninstall-bitcoin"
-    if is-service-installed bitcoin; then
-    	install_service_option="Uninstall Bitcoin Service%remove-service bitcoin"
-    	service_status_option="View Bitcoin Service Status%sudo systemctl status bitcoin"
-	    if is-bitcoin-running; then
-	      bitcoin_service_option="Stop Bitcoin Service%sudo systemctl stop bitcoin"
-	      menu "$title" "$blockchain_info" "$set_config" "$change_directory" "$clear_cache" "$repair_permissions" "$service_status_option" "$bitcoin_service_option" "$install_service_option" "$install_bitcoin_option" "$exit_option"
-	    else
-	      bitcoin_service_option="Start Bitcoin Service%sudo systemctl start bitcoin"
-	      menu "$title" "$set_config" "$change_directory" "$clear_cache" "$repair_permissions" "$service_status_option" "$bitcoin_service_option" "$install_service_option" "$install_bitcoin_option" "$exit_option"
-	    fi
+    if is-bitcoin-running >/dev/null 2>&1; then
+      daemon_toggle_cmd=$stop_daemon_cmd
     else
-    	script_dir=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
-    	install_service_option="Install Bitcoin Service%install-service-template $script_dir/bitcoin.service \"BITCOIND=\`which bitcoind\`\""
-    	menu "$title" "$set_config" "$change_directory" "$clear_cache" "$repair_permissions" "$install_service_option" "$install_bitcoin_option" "$exit_option"
-	fi
+      daemon_toggle_cmd=$start_daemon_cmd
+    fi
+
+    set -- \
+      "$node_info_cmd" \
+      "$sync_status_cmd" \
+      "$wallet_balance_cmd" \
+      "$new_address_cmd" \
+      "$send_coins_cmd" \
+      "$recent_tx_cmd" \
+      "$peer_info_cmd" \
+      "$wallet_list_cmd" \
+      "$wallet_dir_cmd" \
+      "$daemon_toggle_cmd" \
+      "$configure_cmd" \
+      "$change_directory_cmd" \
+      "$repair_permissions_cmd" \
+      "$install_wizard_cmd"
+
+    if is-service-installed bitcoin >/dev/null 2>&1; then
+      service_status_option="Bitcoin service status%sudo systemctl status bitcoin"
+      set -- "$@" "$service_status_option"
+    fi
+
+    uninstall_option="Uninstall Bitcoin%uninstall-bitcoin"
+    set -- "$@" "$uninstall_option" "$exit_option"
   else
-    install_bitcoin_option="Install Bitcoin%install-bitcoin"
-    menu "$title" "$install_bitcoin_option" "$exit_option"
+    set -- "$install_wizard_cmd" "$exit_option"
   fi
+
+  menu "$title" "$@" || true
 }
 
 first_run=1
@@ -61,4 +114,5 @@ while true; do
   fi
 
   display_menu || true
+  printf '\n'
 done

--- a/spells/install/bitcoin/bitcoin-status
+++ b/spells/install/bitcoin/bitcoin-status
@@ -6,8 +6,7 @@ usage() {
         cat <<'USAGE' >&2
 Usage: bitcoin-status
 
-Shows whether Bitcoin Core is installed, running, and synced by inspecting systemd state and recent node logs with coloured sta
-tus labels.
+Shows whether Bitcoin Core is installed, running, and synced by inspecting systemd state and recent node logs with coloured status labels.
 USAGE
 }
 
@@ -18,12 +17,25 @@ case "${1-}" in
         ;;
 esac
 
-
 # Get Bitcoin sync status: 'syncing', 'synced', 'unknown', or 'error'
 
-
 set -eu
-. colors
+
+load_colors() {
+  if command -v colors >/dev/null 2>&1; then
+    # shellcheck source=/dev/null
+    . colors
+    GRAY=${GREY-}
+  else
+    RESET=""
+    GREEN=""
+    GRAY=""
+    YELLOW=""
+    RED=""
+  fi
+}
+
+load_colors
 
 # Returns colored text based on status
 color_for_status() {

--- a/spells/install/bitcoin/install-bitcoin
+++ b/spells/install/bitcoin/install-bitcoin
@@ -6,8 +6,7 @@ usage() {
         cat <<'USAGE' >&2
 Usage: install-bitcoin
 
-Installs Bitcoin Core by downloading the appropriate binary (or building from source), placing bitcoind and bitcoin-cli in /usr
-/local/bin, and announcing the installed version.
+Runs an interactive wizard to install Bitcoin Core (via packages, nix, or upstream binaries), updates bitcoin.conf, and optionally starts the node.
 USAGE
 }
 
@@ -18,101 +17,211 @@ case "${1-}" in
         ;;
 esac
 
-
-# Set Bitcoin version
-
 set -eu
-BITCOIN_VERSION="25.0"
 
-# Function to get Bitcoin binary based on architecture
-get_bitcoin_binary() {
-    local arch
-    arch=$(uname -m)
-    case "$arch" in
-        "x86_64")
-            echo "bitcoin-$BITCOIN_VERSION-x86_64-linux-gnu.tar.gz"
-            ;;
-        "aarch64")
-            echo "bitcoin-$BITCOIN_VERSION-aarch64-linux-gnu.tar.gz"
-            ;;
-        "armv7l")
-            echo "bitcoin-$BITCOIN_VERSION-arm-linux-gnueabihf.tar.gz"
-            ;;
-        *)
-            echo "Unsupported architecture: $arch"
-            exit 1
-    esac
-}
+BITCOIN_VERSION_DEFAULT="25.0"
 
-# Function to install Bitcoin from source
-install_bitcoin_from_source() {
-    tmp_dir="/tmp/bitcoin-install-$(date +%s)"
-    mkdir -p "$tmp_dir"
-    cd "$tmp_dir" || exit 1
-    wget https://bitcoincore.org/bin/bitcoin-core-$BITCOIN_VERSION/bitcoin-$BITCOIN_VERSION.tar.gz 
-    tar -xvf bitcoin-$BITCOIN_VERSION.tar.gz
-    cd bitcoin-$BITCOIN_VERSION || exit 1
-    ./autogen.sh
-    ./configure --disable-wallet
-    make 
-    if [ $? -ne 0 ]; then
-        return 1
+prompt_yes_no() {
+  question=$1
+  default=${2:-y}
+
+  if command -v ask_yn >/dev/null 2>&1; then
+    if ask_yn "$question" "$default"; then
+      return 0
+    else
+      return 1
     fi
-    sudo make install
-    cd ../.. || exit 1
-    rm -rf "$tmp_dir"
+  fi
+
+  suffix="[y/N]"
+  [ "$default" = "y" ] && suffix="[Y/n]"
+  printf "%s %s " "$question" "$suffix"
+  read -r reply
+  [ -z "$reply" ] && reply=$default
+  case "$reply" in
+    [Yy]*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+prompt_with_default() {
+  prompt=$1
+  default_value=$2
+  printf "%s [%s]: " "$prompt" "$default_value"
+  IFS= read -r response
+  if [ -z "$response" ]; then
+    printf "%s" "$default_value"
+  else
+    printf "%s" "$response"
+  fi
+}
+
+detect_distro() {
+  if command -v detect-distro >/dev/null 2>&1; then
+    detect-distro
+    return
+  fi
+
+  if [ -f /etc/os-release ]; then
+    # shellcheck source=/dev/null
+    . /etc/os-release
+    printf "%s" "${ID:-unknown}"
+    return
+  fi
+
+  uname -s
+}
+
+install_with_binary() {
+  BITCOIN_VERSION=$1
+  binary_name=""
+  arch=$(uname -m)
+  case "$arch" in
+    x86_64)
+      binary_name="bitcoin-$BITCOIN_VERSION-x86_64-linux-gnu.tar.gz"
+      ;;
+    aarch64)
+      binary_name="bitcoin-$BITCOIN_VERSION-aarch64-linux-gnu.tar.gz"
+      ;;
+    armv7l)
+      binary_name="bitcoin-$BITCOIN_VERSION-arm-linux-gnueabihf.tar.gz"
+      ;;
+    *)
+      echo "Unsupported architecture: $arch"
+      return 1
+      ;;
+  esac
+
+  bitcoin_url="https://bitcoincore.org/bin/bitcoin-core-$BITCOIN_VERSION/$binary_name"
+  tmp_dir="/tmp/bitcoin-install-$(date +%s)"
+  mkdir -p "$tmp_dir"
+  cd "$tmp_dir"
+  if ! wget "$bitcoin_url"; then
+    echo "Failed to download $bitcoin_url"
+    return 1
+  fi
+  tar -xzf "$binary_name"
+  sudo install -m 0755 -o root -g root -t /usr/local/bin "bitcoin-$BITCOIN_VERSION"/bin/*
+  cd - >/dev/null
+  rm -rf "$tmp_dir"
+  printf "Bitcoin Core version %s installed from upstream binaries.\n" "$BITCOIN_VERSION"
+}
+
+install_with_package_manager() {
+  if command -v apt >/dev/null 2>&1; then
+    sudo apt update && sudo apt install -y bitcoind bitcoin-qt && return 0
+  fi
+
+  if command -v dnf >/dev/null 2>&1; then
+    sudo dnf install -y bitcoin || sudo dnf install -y bitcoind || return 1
     return 0
+  fi
+
+  if command -v pacman >/dev/null 2>&1; then
+    sudo pacman -Sy --noconfirm bitcoind && return 0
+  fi
+
+  if command -v brew >/dev/null 2>&1; then
+    brew install bitcoin-core && return 0
+  fi
+
+  return 1
 }
 
-# Function to install Bitcoin binary
-install_bitcoin_binary() {
-    binary_name=$(get_bitcoin_binary)
-    bitcoin_url="https://bitcoincore.org/bin/bitcoin-core-$BITCOIN_VERSION/$binary_name"
-    tmp_dir="/tmp/bitcoin-install-$(date +%s)"
-    mkdir -p "$tmp_dir"
-    cd "$tmp_dir" || exit 1
-    wget "$bitcoin_url"
-    tar -xzf "$binary_name"
-    sudo install -m 0755 -o root -g root -t /usr/local/bin bitcoin-$BITCOIN_VERSION/bin/*
-    cd - || exit 1
-    rm -rf "$tmp_dir"
-    echo "Bitcoin Core version $BITCOIN_VERSION has been installed successfully."
+package_manager_available() {
+  if command -v apt >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if command -v dnf >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if command -v pacman >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if command -v brew >/dev/null 2>&1; then
+    return 0
+  fi
+
+  return 1
 }
 
-# Function to install Bitcoin for macOS
-install_bitcoin_macos() {
-    tmp_dir="/tmp/bitcoin-install-$(date +%s)"
-    mkdir -p "$tmp_dir"
-    cd "$tmp_dir" || exit 1
-    wget https://bitcoincore.org/bin/bitcoin-core-$BITCOIN_VERSION/bitcoin-$BITCOIN_VERSION-osx64.tar.gz
-    tar -xzf bitcoin-$BITCOIN_VERSION-osx64.tar.gz
-    sudo mv bitcoin-$BITCOIN_VERSION/bin/* /usr/local/bin/
-    cd - || exit 1
-    rm -rf "$tmp_dir"
-    echo "Bitcoin Core version $BITCOIN_VERSION has been installed successfully on macOS."
+install_with_nix() {
+  if command -v nix-env >/dev/null 2>&1; then
+    nix-env -iA nixpkgs.bitcoind
+    return 0
+  fi
+
+  if command -v nix >/dev/null 2>&1; then
+    nix profile install nixpkgs#bitcoind
+    return 0
+  fi
+
+  return 1
 }
 
-# Main function to install Bitcoin
-install_bitcoin() {
-    case "$(uname -s)" in
-        Darwin)
-            install_bitcoin_macos
-            ;;
-        Linux)
-            # If the operating system is Raspbian, we will skip compiling from source and go directly to binary installation.
-            if uname -a | grep -q 'raspberrypi'; then
-                install_bitcoin_binary
-            else
-                if ! install_bitcoin_from_source; then
-                    install_bitcoin_binary
-                fi
-            fi
-            ;;
-        *)
-            echo "Unsupported operating system"
-            exit 1
-    esac
+maybe_run_nixos_rebuild() {
+  if command -v nixos-rebuild >/dev/null 2>&1; then
+    if prompt_yes_no "Run 'sudo nixos-rebuild switch' to activate any configuration changes?" "y"; then
+      sudo nixos-rebuild switch
+    fi
+  fi
 }
 
-# Run the install Bitcoin function
-install_bitcoin
+maybe_start_bitcoind() {
+  if prompt_yes_no "Start bitcoind in the background now?" "y"; then
+    if command -v systemctl >/dev/null 2>&1 && systemctl list-unit-files | grep -q '^bitcoin.service'; then
+      sudo systemctl start bitcoin
+    else
+      bitcoind -daemon || true
+    fi
+  fi
+}
+
+configure_bitcoin_conf() {
+  if prompt_yes_no "Configure bitcoin.conf with sensible defaults now?" "y"; then
+    configure-bitcoin
+  fi
+}
+
+run_installer() {
+  distro=$(detect_distro)
+  version=$(prompt_with_default "Which Bitcoin Core version should be installed?" "$BITCOIN_VERSION_DEFAULT")
+
+  if [ "$distro" = "nixos" ]; then
+    echo "Detected NixOS. Installing via nix profile for user environment."
+    if ! install_with_nix; then
+      echo "Nix tools were not available; falling back to upstream binaries."
+      install_with_binary "$version"
+    fi
+    configure_bitcoin_conf
+    maybe_run_nixos_rebuild
+    maybe_start_bitcoind
+    return
+  fi
+
+  echo "Detected platform: $distro"
+  install_method="binary"
+  if package_manager_available && prompt_yes_no "Use your package manager to install Bitcoin Core?" "y"; then
+    install_method="package"
+  fi
+
+  if [ "$install_method" = "package" ]; then
+    install_with_package_manager || install_with_binary "$version"
+  else
+    install_with_binary "$version"
+  fi
+
+  configure_bitcoin_conf
+  if command -v install-service-template >/dev/null 2>&1; then
+    if prompt_yes_no "Install a system service for bitcoind?" "n"; then
+      script_dir=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+      install-service-template "$script_dir/bitcoin.service" "BITCOIND=$(command -v bitcoind)"
+    fi
+  fi
+  maybe_start_bitcoind
+}
+
+run_installer


### PR DESCRIPTION
## Summary
- add resilient colour loading for bitcoin-status so install-menu can show status reliably
- rebuild bitcoin-menu with direct bitcoin-cli controls, clear install/uninstall options, and service/status helpers
- turn install-bitcoin into an interactive wizard covering distro choices, configuration, NixOS rebuilds, and daemon startup

## Testing
- sh -n spells/install/bitcoin/bitcoin-menu
- sh -n spells/install/bitcoin/bitcoin-status
- sh -n spells/install/bitcoin/install-bitcoin

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930e14e775883208660eaf51c0dbb01)