### PR TITLE
Add node arcanum tests and menu fixes

### DIFF
--- a/.tests/install/node/test-install-node.sh
+++ b/.tests/install/node/test-install-node.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+set -eu
+
+# Locate test helpers
+test_root=$(CDPATH= cd -- "$(dirname "$0")" && pwd -P)
+while [ ! -f "$test_root/test-common.sh" ] && [ "$test_root" != "/" ]; do
+  test_root=$(dirname "$test_root")
+done
+# shellcheck source=/dev/null
+. "$test_root/test-common.sh"
+
+spell_is_executable() {
+  [ -x "$ROOT_DIR/spells/install/node/install-node" ]
+}
+
+run_test_case "install/node/install-node is executable" spell_is_executable
+
+runs_install_with_default_package() {
+  tmp=$(make_tempdir)
+  log="$tmp/manage.log"
+  cat >"$tmp/manage-system-command" <<SHI
+#!/bin/sh
+printf '%s ' "\$@" >>"$log"
+printf '\n' >>"$log"
+SHI
+  chmod +x "$tmp/manage-system-command"
+
+  run_cmd env PATH="$tmp:$PATH" MANAGE_SYSTEM_COMMAND="$tmp/manage-system-command" NODE_PACKAGE_DEFAULT="nodejs-lts" \
+    sh -c "printf '\n' | '$ROOT_DIR/spells/install/node/install-node'"
+
+  assert_success || return 1
+  assert_file_contains "$log" "node nodejs-lts" || return 1
+  assert_output_contains "Installing Node.js" || return 1
+}
+
+run_test_case "install-node installs the default package via manage-system-command" runs_install_with_default_package
+
+respects_user_selected_package() {
+  tmp=$(make_tempdir)
+  log="$tmp/manage.log"
+  cat >"$tmp/manage-system-command" <<SHI
+#!/bin/sh
+printf '%s ' "\$@" >>"$log"
+printf '\n' >>"$log"
+SHI
+  chmod +x "$tmp/manage-system-command"
+
+  run_cmd env PATH="$tmp:$PATH" MANAGE_SYSTEM_COMMAND="$tmp/manage-system-command" \
+    sh -c "printf 'custompkg\\n' | '$ROOT_DIR/spells/install/node/install-node'"
+
+  assert_success || return 1
+  assert_file_contains "$log" "node custompkg" || return 1
+}
+
+run_test_case "install-node accepts a custom package choice" respects_user_selected_package
+
+finish_tests

--- a/.tests/install/node/test-node-menu.sh
+++ b/.tests/install/node/test-node-menu.sh
@@ -1,0 +1,159 @@
+#!/bin/sh
+set -eu
+
+# Locate test helpers
+test_root=$(CDPATH= cd -- "$(dirname "$0")" && pwd -P)
+while [ ! -f "$test_root/test-common.sh" ] && [ "$test_root" != "/" ]; do
+  test_root=$(dirname "$test_root")
+done
+# shellcheck source=/dev/null
+. "$test_root/test-common.sh"
+
+spell_is_executable() {
+  [ -x "$ROOT_DIR/spells/install/node/node-menu" ]
+}
+
+run_test_case "install/node/node-menu is executable" spell_is_executable
+
+make_stub_menu() {
+  tmp=$1
+  cat >"$tmp/menu" <<'SHI'
+#!/bin/sh
+printf '%s\n' "$@" >>"$MENU_LOG"
+kill -TERM "$PPID" 2>/dev/null || exit 0
+SHI
+  chmod +x "$tmp/menu"
+}
+
+menu_shows_install_when_node_missing() {
+  tmp=$(make_tempdir)
+  make_stub_menu "$tmp"
+  cat >"$tmp/exit-label" <<'SHI'
+#!/bin/sh
+printf '%s' "Exit"
+SHI
+  chmod +x "$tmp/exit-label"
+
+  cat >"$tmp/node-status" <<'SHI'
+#!/bin/sh
+echo "not installed"
+SHI
+  chmod +x "$tmp/node-status"
+
+  MENU_LOG="$tmp/menu.log"
+
+  run_cmd env PATH="$tmp:$ROOT_DIR/spells/cantrips" MENU_LOG="$MENU_LOG" \
+    "$ROOT_DIR/spells/install/node/node-menu"
+
+  assert_success || return 1
+  assert_path_exists "$MENU_LOG" || return 1
+  content=$(cat "$MENU_LOG")
+  case "$content" in
+    *"Install Node.js%install-node"* ) : ;;
+    *) TEST_FAILURE_REASON="install option missing"; return 1 ;;
+  esac
+  case "$content" in
+    *'Exit%kill -TERM $PPID'* ) : ;;
+    *) TEST_FAILURE_REASON="exit option missing"; return 1 ;;
+  esac
+}
+
+run_test_case "node-menu shows install flow when Node.js is absent" menu_shows_install_when_node_missing
+
+menu_places_uninstall_before_exit_when_installed() {
+  tmp=$(make_tempdir)
+  make_stub_menu "$tmp"
+
+  cat >"$tmp/exit-label" <<'SHI'
+#!/bin/sh
+printf '%s' "Exit"
+SHI
+  chmod +x "$tmp/exit-label"
+
+  cat >"$tmp/node-status" <<'SHI'
+#!/bin/sh
+echo "installed"
+SHI
+  chmod +x "$tmp/node-status"
+
+  # Stub node tools and service helpers
+  cat >"$tmp/node" <<'SHI'
+#!/bin/sh
+case "$1" in
+  --version)
+    echo "v20.0.0"
+    ;;
+  -e)
+    echo "ok"
+    ;;
+  *)
+    :
+    ;;
+ esac
+SHI
+  chmod +x "$tmp/node"
+
+  cat >"$tmp/npm" <<'SHI'
+#!/bin/sh
+case "$1" in
+  --version)
+    echo "10.0.0"
+    ;;
+  list)
+    echo "npm list"
+    ;;
+  *)
+    :
+    ;;
+ esac
+SHI
+  chmod +x "$tmp/npm"
+
+  cat >"$tmp/is-service-installed" <<'SHI'
+#!/bin/sh
+exit 0
+SHI
+  chmod +x "$tmp/is-service-installed"
+
+  cat >"$tmp/is-service-running" <<'SHI'
+#!/bin/sh
+exit 0
+SHI
+  chmod +x "$tmp/is-service-running"
+
+  MENU_LOG="$tmp/menu.log"
+  run_cmd env PATH="$tmp:$ROOT_DIR/spells/cantrips" MENU_LOG="$MENU_LOG" \
+    "$ROOT_DIR/spells/install/node/node-menu"
+
+  assert_success || return 1
+  assert_path_exists "$MENU_LOG" || return 1
+
+  # Skip the title; inspect menu entries
+  entries=$(tail -n +2 "$MENU_LOG")
+  last_line=$(printf '%s\n' "$entries" | tail -n 1)
+  second_last=$(printf '%s\n' "$entries" | tail -n 2 | head -n 1)
+
+  case "$second_last" in
+    "Uninstall Node.js%uninstall-node") : ;;
+    *) TEST_FAILURE_REASON="uninstall option should be second to last"; return 1 ;;
+  esac
+
+  case "$last_line" in
+    *'%kill -TERM $PPID') : ;;
+    *) TEST_FAILURE_REASON="exit option should be last"; return 1 ;;
+  esac
+
+  case "$entries" in
+    *"Show Node version%node --version"* ) : ;; 
+    *) TEST_FAILURE_REASON="version entry missing"; return 1 ;;
+  esac
+
+  case "$entries" in
+    *"Restart Node service%sudo systemctl restart node"* ) : ;; 
+    *) TEST_FAILURE_REASON="service restart entry missing"; return 1 ;;
+  esac
+}
+
+run_test_case "node-menu orders uninstall before exit and surfaces node helpers" menu_places_uninstall_before_exit_when_installed
+
+finish_tests

--- a/.tests/install/node/test-node-status.sh
+++ b/.tests/install/node/test-node-status.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+set -eu
+
+# Locate test helpers
+test_root=$(CDPATH= cd -- "$(dirname "$0")" && pwd -P)
+while [ ! -f "$test_root/test-common.sh" ] && [ "$test_root" != "/" ]; do
+  test_root=$(dirname "$test_root")
+done
+# shellcheck source=/dev/null
+. "$test_root/test-common.sh"
+
+spell_is_executable() {
+  [ -x "$ROOT_DIR/spells/install/node/node-status" ]
+}
+
+run_test_case "install/node/node-status is executable" spell_is_executable
+
+reports_not_installed_without_node_binary() {
+  tmp=$(make_tempdir)
+  run_cmd env PATH="$tmp:$ROOT_DIR/spells/cantrips:$ROOT_DIR/spells/.imps:$ROOT_DIR/spells/.imps/menu" \
+    "$ROOT_DIR/spells/install/node/node-status"
+
+  assert_success || return 1
+  assert_output_contains "not installed" || return 1
+}
+
+run_test_case "node-status reports not installed when node is absent" reports_not_installed_without_node_binary
+
+reports_installed_when_node_exists() {
+  tmp=$(make_tempdir)
+  cat >"$tmp/node" <<'SHI'
+#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "v22.0.0"
+  exit 0
+fi
+exit 0
+SHI
+  chmod +x "$tmp/node"
+
+  run_cmd env PATH="$tmp:$ROOT_DIR/spells/cantrips:$ROOT_DIR/spells/.imps:$ROOT_DIR/spells/.imps/menu" \
+    "$ROOT_DIR/spells/install/node/node-status"
+
+  assert_success || return 1
+  assert_output_contains "installed, npm missing" || return 1
+}
+
+run_test_case "node-status flags missing npm" reports_installed_when_node_exists
+
+reports_running_service_state() {
+  tmp=$(make_tempdir)
+  cat >"$tmp/node" <<'SHI'
+#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "v20.1.0"
+  exit 0
+fi
+exit 0
+SHI
+  chmod +x "$tmp/node"
+
+  cat >"$tmp/npm" <<'SHI'
+#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "10.0.0"
+  exit 0
+fi
+exit 0
+SHI
+  chmod +x "$tmp/npm"
+
+  cat >"$tmp/is-service-installed" <<'SHI'
+#!/bin/sh
+exit 0
+SHI
+  chmod +x "$tmp/is-service-installed"
+
+  cat >"$tmp/is-service-running" <<'SHI'
+#!/bin/sh
+exit 0
+SHI
+  chmod +x "$tmp/is-service-running"
+
+  run_cmd env PATH="$tmp:$ROOT_DIR/spells/cantrips:$ROOT_DIR/spells/.imps:$ROOT_DIR/spells/.imps/menu" \
+    "$ROOT_DIR/spells/install/node/node-status"
+
+  assert_success || return 1
+  assert_output_contains "service running" || return 1
+}
+
+run_test_case "node-status reports running service when detectors succeed" reports_running_service_state
+
+finish_tests

--- a/.tests/install/node/test-uninstall-node.sh
+++ b/.tests/install/node/test-uninstall-node.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+set -eu
+
+# Locate test helpers
+test_root=$(CDPATH= cd -- "$(dirname "$0")" && pwd -P)
+while [ ! -f "$test_root/test-common.sh" ] && [ "$test_root" != "/" ]; do
+  test_root=$(dirname "$test_root")
+done
+# shellcheck source=/dev/null
+. "$test_root/test-common.sh"
+
+spell_is_executable() {
+  [ -x "$ROOT_DIR/spells/install/node/uninstall-node" ]
+}
+
+run_test_case "install/node/uninstall-node is executable" spell_is_executable
+
+runs_uninstall_with_package_override() {
+  tmp=$(make_tempdir)
+  log="$tmp/manage.log"
+  cat >"$tmp/manage-system-command" <<SHI
+#!/bin/sh
+printf '%s ' "\$@" >>"$log"
+printf '\n' >>"$log"
+SHI
+  chmod +x "$tmp/manage-system-command"
+
+  run_cmd env PATH="$tmp:$PATH" MANAGE_SYSTEM_COMMAND="$tmp/manage-system-command" NODE_PACKAGE="node-custom" \
+    sh -c "printf '\n' | '$ROOT_DIR/spells/install/node/uninstall-node'"
+
+  assert_success || return 1
+  assert_file_contains "$log" "--uninstall node node-custom" || return 1
+  assert_output_contains "removal" || return 1
+}
+
+run_test_case "uninstall-node removes the requested package" runs_uninstall_with_package_override
+
+finish_tests

--- a/spells/install/node/install-node
+++ b/spells/install/node/install-node
@@ -1,0 +1,86 @@
+#!/bin/sh
+
+# Install Node.js using the available package manager, with NixOS rebuild support.
+
+usage() {
+        cat <<'USAGE' >&2
+Usage: install-node
+
+Runs a short wizard to install Node.js using the system package manager (or nix-env on NixOS),
+prompting for package choices and optionally running nixos-rebuild when appropriate.
+USAGE
+}
+
+case "${1-}" in
+--help|--usage|-h)
+        usage
+        exit 0
+        ;;
+esac
+
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+manage_cmd=${MANAGE_SYSTEM_COMMAND:-manage-system-command}
+
+if ! command -v "$manage_cmd" >/dev/null 2>&1; then
+  if [ -x "$script_dir/../core/manage-system-command" ]; then
+    manage_cmd="$script_dir/../core/manage-system-command"
+  else
+    printf '%s\n' "install-node: unable to find manage-system-command" >&2
+    exit 1
+  fi
+fi
+
+detect_nixos() {
+  if [ -d /etc/nixos ] || [ -f /etc/NIXOS ] || grep -qi 'ID=nixos' /etc/os-release 2>/dev/null; then
+    return 0
+  fi
+  return 1
+}
+
+prompt() {
+  message=$1
+  default_value=$2
+  printf '%s [%s]: ' "$message" "$default_value" >&2
+  read -r response || response=""
+  if [ -z "$response" ]; then
+    response=$default_value
+  fi
+  printf '%s' "$response"
+}
+
+package_default=${NODE_PACKAGE_DEFAULT:-nodejs}
+node_package=$(prompt "Which Node.js package should be installed?" "$package_default")
+
+# Allow users to override per-manager packages to handle distro differences.
+export NIX_PACKAGE=${NIX_PACKAGE:-$node_package}
+export APT_PACKAGE=${APT_PACKAGE:-$node_package}
+export DNF_PACKAGE=${DNF_PACKAGE:-$node_package}
+export YUM_PACKAGE=${YUM_PACKAGE:-$node_package}
+export ZYPPER_PACKAGE=${ZYPPER_PACKAGE:-$node_package}
+export PACMAN_PACKAGE=${PACMAN_PACKAGE:-$node_package}
+export APK_PACKAGE=${APK_PACKAGE:-$node_package}
+export PKGIN_PACKAGE=${PKGIN_PACKAGE:-$node_package}
+
+printf '\nInstalling Node.js using %s...\n' "$manage_cmd"
+"$manage_cmd" node "$node_package"
+
+if detect_nixos && command -v nixos-rebuild >/dev/null 2>&1; then
+  printf '\nA NixOS system was detected. Run a system rebuild now to pick up configuration changes? [y/N]: '
+  read -r rebuild || rebuild=""
+  case "$rebuild" in
+    [Yy]*)
+      if command -v sudo >/dev/null 2>&1; then
+        sudo nixos-rebuild switch
+      else
+        nixos-rebuild switch
+      fi
+      ;;
+    *)
+      printf '%s\n' "Skipping nixos-rebuild. Run 'sudo nixos-rebuild switch' later if you added Node.js to configuration.nix."
+      ;;
+  esac
+fi
+
+printf '\nNode.js installation complete.\n'

--- a/spells/install/node/node-menu
+++ b/spells/install/node/node-menu
@@ -1,0 +1,110 @@
+#!/bin/sh
+
+# Present the Node.js management menu.
+
+case "${1-}" in
+  -h|--help)
+    printf 'Usage: node-menu\n'
+    printf 'Displays the Node.js management menu.\n'
+    exit 0
+    ;;
+esac
+
+set -eu
+. colors
+
+trap 'exit 0' INT TERM
+
+command_available() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+is_node_installed() {
+  command_available node
+}
+
+node_service_name() {
+  for candidate in ${NODE_SERVICE-} node nodejs node-app; do
+    [ -n "$candidate" ] || continue
+    if command_available is-service-installed && is-service-installed "$candidate" >/dev/null 2>&1; then
+      printf '%s' "$candidate"
+      return 0
+    fi
+    if command_available systemctl && systemctl list-unit-files --type=service --no-pager 2>/dev/null | grep -q "^${candidate}\\.service"; then
+      printf '%s' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+service_entries() {
+  if service_name=$(node_service_name); then
+    status="Service Status%sudo systemctl status $service_name"
+    if command_available is-service-running && is-service-running "$service_name" >/dev/null 2>&1; then
+      toggle="Restart Node service%sudo systemctl restart $service_name"
+      stop="Stop Node service%sudo systemctl stop $service_name"
+    elif command_available systemctl && systemctl is-active "$service_name" >/dev/null 2>&1; then
+      toggle="Restart Node service%sudo systemctl restart $service_name"
+      stop="Stop Node service%sudo systemctl stop $service_name"
+    else
+      toggle="Start Node service%sudo systemctl start $service_name"
+      stop=""
+    fi
+    printf '%s\n%s\n' "$status" "$toggle"
+    [ -n "$stop" ] && printf '%s\n' "$stop"
+  fi
+}
+
+version_entries() {
+  if command_available node; then
+    printf 'Show Node version%%node --version\n'
+    printf 'Show Node binary path%%command -v node\n'
+    printf 'Runtime platform%%node -e "console.log(`${process.platform}-${process.arch}`)"\n'
+    printf 'Quick health check%%node -e "console.log(`Node OK: ${process.version}`)"\n'
+  fi
+  if command_available npm; then
+    printf 'Show npm version%%npm --version\n'
+    printf 'List global npm packages%%npm list -g --depth=0\n'
+  fi
+}
+
+display_menu() {
+  title="${BOLD}${CYAN}Node.js: $(node-status)"
+  exit_label=$(exit-label)
+  exit_option="${exit_label}%kill -TERM \$PPID"
+  install_option="Install Node.js%install-node"
+  uninstall_option="Uninstall Node.js%uninstall-node"
+
+  service_opts=$(service_entries)
+  version_opts=$(version_entries)
+
+  set --
+  if is_node_installed; then
+    old_ifs=$IFS
+    IFS=$(printf '\n')
+    for line in $version_opts; do
+      [ -n "$line" ] && set -- "$@" "$line"
+    done
+    for line in $service_opts; do
+      [ -n "$line" ] && set -- "$@" "$line"
+    done
+    IFS=$old_ifs
+    set -- "$@" "$uninstall_option" "$exit_option"
+    menu "$title" "$@" || true
+  else
+    menu "$title" "$install_option" "$exit_option" || true
+  fi
+}
+
+first_run=1
+while :; do
+  if [ "$first_run" -eq 0 ]; then
+    printf '\n'
+  else
+    first_run=0
+  fi
+  display_menu || true
+  # Loop to refresh status
+  :
+done

--- a/spells/install/node/node-status
+++ b/spells/install/node/node-status
@@ -1,0 +1,94 @@
+#!/bin/sh
+
+# Report installation and runtime status for Node.js.
+
+usage() {
+        cat <<'USAGE' >&2
+Usage: node-status
+
+Reports whether Node.js is installed, whether npm is available, and whether a Node-related service is running.
+USAGE
+}
+
+case "${1-}" in
+--help|--usage|-h)
+        usage
+        exit 0
+        ;;
+esac
+
+set -eu
+. colors
+
+# Older scripts expect GRAY, so mirror GREY when missing.
+GRAY=${GRAY:-${GREY-}}
+
+color_for_status() {
+  case "$1" in
+    "installed, service running"|"installed")
+      printf "%s" "$GREEN"
+      ;;
+    "installed, service stopped"|"installed, npm missing")
+      printf "%s" "$YELLOW"
+      ;;
+    "not installed")
+      printf "%s" "$GRAY"
+      ;;
+    *)
+      printf "%s" "$RED"
+      ;;
+  esac
+}
+
+command_available() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+node_service_name() {
+  for candidate in ${NODE_SERVICE-} node nodejs node-app; do
+    [ -n "$candidate" ] || continue
+    if command_available is-service-installed && is-service-installed "$candidate" >/dev/null 2>&1; then
+      printf '%s' "$candidate"
+      return 0
+    fi
+    if command_available systemctl && systemctl list-unit-files --type=service --no-pager 2>/dev/null | grep -q "^${candidate}\\.service"; then
+      printf '%s' "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+get_node_status() {
+  if ! command_available node; then
+    status="not installed"
+    printf "%s%s%s\n" "$(color_for_status "$status")" "$status" "$RESET"
+    return
+  fi
+
+  if ! node --version >/dev/null 2>&1; then
+    status="installed, error"
+    printf "%s%s%s\n" "$(color_for_status "$status")" "$status" "$RESET"
+    return
+  fi
+
+  if ! command_available npm; then
+    status="installed, npm missing"
+  else
+    status="installed"
+  fi
+
+  if service_name=$(node_service_name); then
+    if command_available is-service-running && is-service-running "$service_name" >/dev/null 2>&1; then
+      status="installed, service running"
+    elif command_available systemctl && systemctl is-active "$service_name" >/dev/null 2>&1; then
+      status="installed, service running"
+    else
+      status="installed, service stopped"
+    fi
+  fi
+
+  printf "%s%s%s\n" "$(color_for_status "$status")" "$status" "$RESET"
+}
+
+get_node_status

--- a/spells/install/node/uninstall-node
+++ b/spells/install/node/uninstall-node
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+# Uninstall Node.js using the available package manager, with optional NixOS rebuild.
+
+usage() {
+        cat <<'USAGE' >&2
+Usage: uninstall-node
+
+Removes Node.js using the detected package manager and can trigger a nixos-rebuild on NixOS systems.
+USAGE
+}
+
+case "${1-}" in
+--help|--usage|-h)
+        usage
+        exit 0
+        ;;
+esac
+
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+manage_cmd=${MANAGE_SYSTEM_COMMAND:-manage-system-command}
+
+if ! command -v "$manage_cmd" >/dev/null 2>&1; then
+  if [ -x "$script_dir/../core/manage-system-command" ]; then
+    manage_cmd="$script_dir/../core/manage-system-command"
+  else
+    printf '%s\n' "uninstall-node: unable to find manage-system-command" >&2
+    exit 1
+  fi
+fi
+
+detect_nixos() {
+  if [ -d /etc/nixos ] || [ -f /etc/NIXOS ] || grep -qi 'ID=nixos' /etc/os-release 2>/dev/null; then
+    return 0
+  fi
+  return 1
+}
+
+node_package_default=${NODE_PACKAGE_DEFAULT:-nodejs}
+node_package=${NODE_PACKAGE:-$node_package_default}
+
+printf '\nRemoving Node.js using %s...\n' "$manage_cmd"
+"$manage_cmd" --uninstall node "$node_package"
+
+if detect_nixos && command -v nixos-rebuild >/dev/null 2>&1; then
+  printf '\nA NixOS system was detected. Run a system rebuild to propagate removal? [y/N]: '
+  read -r rebuild || rebuild=""
+  case "$rebuild" in
+    [Yy]*)
+      if command -v sudo >/dev/null 2>&1; then
+        sudo nixos-rebuild switch
+      else
+        nixos-rebuild switch
+      fi
+      ;;
+    *)
+      printf '%s\n' "Skipping nixos-rebuild. Run 'sudo nixos-rebuild switch' later if you removed Node.js from configuration.nix."
+      ;;
+  esac
+fi
+
+printf '\nNode.js removal complete.\n'

--- a/spells/install/tor/tor-menu
+++ b/spells/install/tor/tor-menu
@@ -43,7 +43,6 @@ display_menu() {
   cli_verify="Verify torrc%tor --verify-config"
   cli_fingerprint="Show Fingerprint%tor --list-fingerprint"
   cli_dump="Print Effective Config%tor --dump-config short"
-
   set_config="Configure Tor%configure-tor"
   repair_permissions="Repair Permissions%sudo repair-tor-permissions"
   tor_lightning="Tor Lightning (Install Wizard)%install-tor"


### PR DESCRIPTION
## Summary
- fix the install-node prompt so package selection is captured without mixing in prompt text
- correct node-menu formatting and newline handling for version and service actions
- add regression coverage for node install/uninstall, status detection, and menu layout

## Testing
- .tests/install/node/test-install-node.sh && .tests/install/node/test-uninstall-node.sh && .tests/install/node/test-node-status.sh && .tests/install/node/test-node-menu.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69314009395c832083f18b9069428860)