### PR TITLE
Version 1.3 separates Notice clause for clarity

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
- ,___,   OPEN WIZARDRY LICENSE 1.2
+ ,___,   OPEN WIZARDRY LICENSE 1.3
  (O,O)
  /)  )   Permission: You may use, copy,
 ="=="=   modify, and share this project for
@@ -23,9 +23,10 @@ No other files must be published.
 
 No Enclosure: Modified files you share must
 remain exclusively under this license, without
-additional restrictions. This license must
-accompany any public distribution of this
-project or its files.
+additional restrictions.
+
+Notice: This license must accompany any public
+distribution of this project or its files.
 
 Violation: Any violation of this license voids
 the permissions granted herein until set right.


### PR DESCRIPTION
With the notice clause as part of the No Enclosure clause as it was before, it could be read as implying it only applied to modifed files. This was not intended, so the clause was separated for clarity and to close this potential loophole.