### PR TITLE
Revised opening exhortation

### DIFF
--- a/OATH
+++ b/OATH
@@ -1,43 +1,70 @@
-By using this software (wizardry), you agree to take and abide by the Wizard's
-Oath. To take the Oath, recite it aloud.
+Wizardry is offered with the expectation
+that those who use it will take and
+answer to the Wizard's Oath in their own
+conscience. To take the Oath, recite it
+aloud.
 
 ~ THE WIZARD'S OATH ~
 
-In Life's name and for Life's sake, I say that I will use the Art for nothing
-but the service of that Life. I will guard growth and ease pain. I will
-fight to preserve what grows and lives well in its own way; and I will change
-no object or creature unless its growth and life, or that of the system of
-which it is part, are threatened. To these ends, in the practice of my Art,
-I will put aside fear for courage, and death for life, when it is right to
-do so -- till Universe's end. I will look always toward the Heart of Time,
-where all times are one, where all our sundered worlds lie whole, as they
-were meant to be.
+In Life's name and for Life's sake, I say
+that I will use the Art for nothing but
+the service of that Life. I will guard
+growth and ease pain. I will fight to
+preserve what grows and lives well in
+its own way; and I will change no object
+or creature unless its growth and life,
+or that of the system of which it is
+part, are threatened. To these ends, in
+the practice of my Art, I will put aside
+fear for courage, and death for life,
+when it is right to do so -- till
+Universe's end. I will look always
+toward the Heart of Time, where all
+times are one, where all our sundered
+worlds lie whole, as they were meant to
+be.
 
 -Diane Duane, Young Wizards book series
 
-~ The WIZARD'S OATH (FOR CAT WIZARDS) ~
+~ THE WIZARD'S OATH (FOR CAT WIZARDS) ~
 
-I will meet the cruel and the cowardly today, liars and the envious, the
-uncaring and unknowing: they will be all around. But their numbers and
-their carelessness do not mean I have to be like them. For my own part,
-I know my job; my commission comes from Those Who Are. My paw raised is
-Their paw on the neck of the Serpent, now and always. I shall walk through
-Their worlds as do the Powers that Be, seeing and knowing with Them and
-for Them, tending Their worlds as if they were mine: for so indeed they
-are. Silently shall I strive to go my way, as They do, doing my work unseen;
-the light needs no reminding by me of good deeds done by night. And in this
-long progress through all that is, though I will know doubt and fear in the
-strange places where I must walk, I will put these both aside, as the Oath
-requires, and hold myself to my work ... for if They and I together cannot
-mend what is marred, who can? And having done my work aright, though I may
-know weariness at day's end, come awakening I shall rise up and say again,
-with Them, as if surprised, "behold, the world is made new ... !"
+I will meet the cruel and the cowardly
+today, liars and the envious, the
+uncaring and unknowing: they will be all
+around. But their numbers and their
+carelessness do not mean I have to be
+like them. For my own part, I know my
+job; my commission comes from Those Who
+Are. My paw raised is Their paw on the
+neck of the Serpent, now and always. I
+shall walk through Their worlds as do
+the Powers that Be, seeing and knowing
+with Them and for Them, tending Their
+worlds as if they were mine: for so
+indeed they are. Silently shall I strive
+to go my way, as They do, doing my work
+unseen; the light needs no reminding by
+me of good deeds done by night. And in
+this long progress through all that is,
+though I will know doubt and fear in the
+strange places where I must walk, I will
+put these both aside, as the Oath
+requires, and hold myself to my work ...
+for if They and I together cannot mend
+what is marred, who can? And having done
+my work aright, though I may know
+weariness at day's end, come awakening I
+shall rise up and say again, with Them,
+as if surprised, "behold, the world is
+made new ... !"
 
 -Diane Duane, Feline Wizards series
 
 ~ THE WIZARD'S OATH EXPLAINED ~
 
-The main point of the Wizard's Oath is a conscious opposition to entropy.
+The main point of the Wizard's Oath is a
+conscious opposition to entropy.
 
-You may take an alternative version of the Wizard's Oath that you write
+You may take an alternative version of
+the Wizard's Oath that you write
 yourself.


### PR DESCRIPTION
Reduced the opening exhortation from a legal tenor to an ethical call to conscience; when framed legally, the OATH could be read as an unenforceable part of the LICENSE and weaken the LICENSE. This was not intended, and personal conscience is in any case the proper mode for the OATH.