### PR TITLE
Enable zsh nonomatch locally in invoke-wizardry to prevent glob errors

### DIFF
--- a/spells/.imps/sys/invoke-wizardry
+++ b/spells/.imps/sys/invoke-wizardry
@@ -117,6 +117,9 @@ _invoke_wizardry() {
     _iw_msg="invoke-wizardry: Entering _invoke_wizardry function"
     printf '%s\n' "$_iw_msg" >> "$_iw_debug_file" 2>/dev/null || :
   fi
+  if eval '[ -n "${ZSH_VERSION+x}" ]' 2>/dev/null; then
+    setopt localoptions nonomatch
+  fi
   
   printf '%s\n' "[invoke-wizardry] Checking WIZARDRY_DIR: ${WIZARDRY_DIR-<unset>}" >&2
   if [ -z "${WIZARDRY_DIR-}" ]; then


### PR DESCRIPTION
### Motivation
- Zsh can abort on unmatched globs (nonomatch behavior) when user spellbook is empty, causing a `no matches found` error and parse failures during sourcing. 
- The crash observed at `parse error near 'fi'` was caused by zsh treating `SPELLBOOK_DIR/*` as a failing glob expansion. 
- The goal is to make `invoke-wizardry` robust when sourced in zsh shells regardless of the user's glob option settings. 

### Description
- Detect when running under zsh inside the `_invoke_wizardry` function and enable `setopt localoptions nonomatch` to prevent nomatch aborts locally. 
- The change is minimal and scoped to the function so zsh option changes do not leak to the user's shell. 
- No other logic or behavior of the loader was modified; the opt-in for `nonomatch` is only applied when zsh is detected. 

### Testing
- Attempted to source the script under zsh with `zsh -c 'source /workspace/wizardry/spells/.imps/sys/invoke-wizardry >/dev/null'`, but the test could not run because `zsh` is not installed in the current environment (failed due to environment limitation). 
- The change was committed to the repository successfully via automated `git commit` (succeeded). 
- Static inspection of the modified file confirms the `setopt localoptions nonomatch` is placed early in `_invoke_wizardry` to guard subsequent glob operations (automated linting not available in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694bffa166508320bfac6d0af3d4aaf0)