### PR TITLE
Stabilize command-not-found handler eval in invoke-wizardry

### DIFF
--- a/spells/.imps/sys/invoke-wizardry
+++ b/spells/.imps/sys/invoke-wizardry
@@ -719,164 +719,196 @@ function brace_delta(s, n, m) {
         printf '%s\n' "$_iw_msg" >> "$_iw_debug_file" 2>/dev/null || :
       fi
       # Bash-specific command_not_found_handle
-      eval 'command_not_found_handle() {
-        # Debug logging for command_not_found_handle
-        if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-          _cnf_file="${HOME-}/.wizardry-debug.log"
-          _cnf_msg="CNF: command not found: $1 (args: $*)"
-          printf '\''%s\n'\'' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+      _iw_cnf_name="command_not_found_handle"
+      _iw_cnf_body=$(cat <<'IW_CNF_EOF'
+# Debug logging for command_not_found_handle
+if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+  _cnf_file="${HOME-}/.wizardry-debug.log"
+  _cnf_msg="CNF: command not found: $1 (args: $*)"
+  printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+fi
+
+# Prevent infinite recursion - check if already in handler
+if [ "${_WIZARDRY_IN_CNF_HANDLER-}" = "1" ]; then
+  if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+    _cnf_file="${HOME-}/.wizardry-debug.log"
+    _cnf_msg="CNF: recursion detected, bailing out"
+    printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+  fi
+  printf '%s: command not found\n' "$1" >&2
+  return 127
+fi
+_WIZARDRY_IN_CNF_HANDLER=1
+
+# Try word-of-binding for autoloading (handles hotloaded spells)
+_cnf_wob="$WIZARDRY_DIR/spells/.imps/sys/word-of-binding"
+if [ -n "${WIZARDRY_DIR-}" ] && [ -x "$_cnf_wob" ]; then
+  if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+    _cnf_file="${HOME-}/.wizardry-debug.log"
+    _cnf_msg="CNF: trying word-of-binding for: $1"
+    printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+  fi
+  if "$_cnf_wob" "$@" 2>/dev/null; then
+    if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+      _cnf_file="${HOME-}/.wizardry-debug.log"
+      _cnf_msg="CNF: word-of-binding succeeded for: $1"
+      printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+    fi
+    unset _WIZARDRY_IN_CNF_HANDLER
+    return 0
+  fi
+  if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+    _cnf_file="${HOME-}/.wizardry-debug.log"
+    _cnf_msg="CNF: word-of-binding failed for: $1"
+    printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+  fi
+fi
+# Fall back to parse for recursive grammar parsing
+_cnf_parse="$WIZARDRY_DIR/spells/.imps/lex/parse"
+if [ -n "${WIZARDRY_DIR-}" ] && [ -x "$_cnf_parse" ]; then
+  if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+    _cnf_file="${HOME-}/.wizardry-debug.log"
+    _cnf_msg="CNF: trying parse for: $1"
+    printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+  fi
+  if "$_cnf_parse" "$@" 2>/dev/null; then
+    if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+      _cnf_file="${HOME-}/.wizardry-debug.log"
+      _cnf_msg="CNF: parse succeeded for: $1"
+      printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+    fi
+    unset _WIZARDRY_IN_CNF_HANDLER
+    return 0
+  fi
+  if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+    _cnf_file="${HOME-}/.wizardry-debug.log"
+    _cnf_msg="CNF: parse failed for: $1"
+    printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+  fi
+fi
+# Command truly not found - return 127
+unset _WIZARDRY_IN_CNF_HANDLER
+if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+  _cnf_file="${HOME-}/.wizardry-debug.log"
+  _cnf_msg="CNF: command truly not found: $1"
+  printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+fi
+printf '%s: command not found\n' "$1" >&2
+return 127
+IW_CNF_EOF
+      )
+      _iw_cnf_body="${_iw_cnf_name}() {
+${_iw_cnf_body}
+}"
+      if eval "$_iw_cnf_body"; then
+        printf '%s\n' "[invoke-wizardry] command_not_found_handle installed (bash)" >&2
+      else
+        printf '%s\n' "[invoke-wizardry] ERROR: failed to install command_not_found_handle" >&2
+        if [ -n "$_iw_debug_file" ]; then
+          _iw_msg="invoke-wizardry: command_not_found_handle eval failed; dumping body"
+          printf '%s\n' "$_iw_msg" >> "$_iw_debug_file" 2>/dev/null || :
+          printf '%s\n' "$_iw_cnf_body" | nl -ba >> "$_iw_debug_file" 2>/dev/null || :
         fi
-        
-        # Prevent infinite recursion - check if already in handler
-        if [ "${_WIZARDRY_IN_CNF_HANDLER-}" = "1" ]; then
-          if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-            _cnf_file="${HOME-}/.wizardry-debug.log"
-            _cnf_msg="CNF: recursion detected, bailing out"
-            printf '\''%s\n'\'' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-          fi
-          printf '\''%s: command not found\n'\'' "$1" >&2
-          return 127
-        fi
-        _WIZARDRY_IN_CNF_HANDLER=1
-        
-        # Try word-of-binding for autoloading (handles hotloaded spells)
-        _cnf_wob="$WIZARDRY_DIR/spells/.imps/sys/word-of-binding"
-        if [ -n "${WIZARDRY_DIR-}" ] && [ -x "$_cnf_wob" ]; then
-          if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-            _cnf_file="${HOME-}/.wizardry-debug.log"
-            _cnf_msg="CNF: trying word-of-binding for: $1"
-            printf '\''%s\n'\'' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-          fi
-          if "$_cnf_wob" "$@" 2>/dev/null; then
-            if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-              _cnf_file="${HOME-}/.wizardry-debug.log"
-              _cnf_msg="CNF: word-of-binding succeeded for: $1"
-              printf '\''%s\n'\'' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-            fi
-            unset _WIZARDRY_IN_CNF_HANDLER
-            return 0
-          fi
-          if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-            _cnf_file="${HOME-}/.wizardry-debug.log"
-            _cnf_msg="CNF: word-of-binding failed for: $1"
-            printf '\''%s\n'\'' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-          fi
-        fi
-        # Fall back to parse for recursive grammar parsing
-        _cnf_parse="$WIZARDRY_DIR/spells/.imps/lex/parse"
-        if [ -n "${WIZARDRY_DIR-}" ] && [ -x "$_cnf_parse" ]; then
-          if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-            _cnf_file="${HOME-}/.wizardry-debug.log"
-            _cnf_msg="CNF: trying parse for: $1"
-            printf '\''%s\n'\'' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-          fi
-          if "$_cnf_parse" "$@" 2>/dev/null; then
-            if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-              _cnf_file="${HOME-}/.wizardry-debug.log"
-              _cnf_msg="CNF: parse succeeded for: $1"
-              printf '\''%s\n'\'' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-            fi
-            unset _WIZARDRY_IN_CNF_HANDLER
-            return 0
-          fi
-          if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-            _cnf_file="${HOME-}/.wizardry-debug.log"
-            _cnf_msg="CNF: parse failed for: $1"
-            printf '\''%s\n'\'' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-          fi
-        fi
-        # Command truly not found - return 127
-        unset _WIZARDRY_IN_CNF_HANDLER
-        if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-          _cnf_file="${HOME-}/.wizardry-debug.log"
-          _cnf_msg="CNF: command truly not found: $1"
-          printf '\''%s\n'\'' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-        fi
-        printf '\''%s: command not found\n'\'' "$1" >&2
-        return 127
-      }'
+      fi
+      unset _iw_cnf_body _iw_cnf_name
     elif eval '[ -n "${ZSH_VERSION+x}" ]' 2>/dev/null; then
       if [ -n "$_iw_debug_file" ]; then
         _iw_msg="invoke-wizardry: Zsh detected, installing command_not_found_handler"
         printf '%s\n' "$_iw_msg" >> "$_iw_debug_file" 2>/dev/null || :
       fi
       # Zsh-specific command_not_found_handler
-      eval 'command_not_found_handler() {
-        # Debug logging for command_not_found_handler
-        if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-          _cnf_file="${HOME-}/.wizardry-debug.log"
-          _cnf_msg="CNF: command not found: $1 (args: $*)"
-          printf '\''%s\n'\'' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+      _iw_cnf_name="command_not_found_handler"
+      _iw_cnf_body=$(cat <<'IW_CNF_EOF'
+# Debug logging for command_not_found_handler
+if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+  _cnf_file="${HOME-}/.wizardry-debug.log"
+  _cnf_msg="CNF: command not found: $1 (args: $*)"
+  printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+fi
+
+# Prevent infinite recursion - check if already in handler
+if [ "${_WIZARDRY_IN_CNF_HANDLER-}" = "1" ]; then
+  if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+    _cnf_file="${HOME-}/.wizardry-debug.log"
+    _cnf_msg="CNF: recursion detected, bailing out"
+    printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+  fi
+  printf '%s: command not found\n' "$1" >&2
+  return 127
+fi
+_WIZARDRY_IN_CNF_HANDLER=1
+
+# Try word-of-binding for autoloading (handles hotloaded spells)
+_cnf_wob="$WIZARDRY_DIR/spells/.imps/sys/word-of-binding"
+if [ -n "${WIZARDRY_DIR-}" ] && [ -x "$_cnf_wob" ]; then
+  if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+    _cnf_file="${HOME-}/.wizardry-debug.log"
+    _cnf_msg="CNF: trying word-of-binding for: $1"
+    printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+  fi
+  if "$_cnf_wob" "$@" 2>/dev/null; then
+    if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+      _cnf_file="${HOME-}/.wizardry-debug.log"
+      _cnf_msg="CNF: word-of-binding succeeded for: $1"
+      printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+    fi
+    unset _WIZARDRY_IN_CNF_HANDLER
+    return 0
+  fi
+  if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+    _cnf_file="${HOME-}/.wizardry-debug.log"
+    _cnf_msg="CNF: word-of-binding failed for: $1"
+    printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+  fi
+fi
+# Fall back to parse for recursive grammar parsing
+_cnf_parse="$WIZARDRY_DIR/spells/.imps/lex/parse"
+if [ -n "${WIZARDRY_DIR-}" ] && [ -x "$_cnf_parse" ]; then
+  if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+    _cnf_file="${HOME-}/.wizardry-debug.log"
+    _cnf_msg="CNF: trying parse for: $1"
+    printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+  fi
+  if "$_cnf_parse" "$@" 2>/dev/null; then
+    if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+      _cnf_file="${HOME-}/.wizardry-debug.log"
+      _cnf_msg="CNF: parse succeeded for: $1"
+      printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+    fi
+    unset _WIZARDRY_IN_CNF_HANDLER
+    return 0
+  fi
+  if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+    _cnf_file="${HOME-}/.wizardry-debug.log"
+    _cnf_msg="CNF: parse failed for: $1"
+    printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+  fi
+fi
+# Command truly not found - return 127
+unset _WIZARDRY_IN_CNF_HANDLER
+if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+  _cnf_file="${HOME-}/.wizardry-debug.log"
+  _cnf_msg="CNF: command truly not found: $1"
+  printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+fi
+printf '%s: command not found\n' "$1" >&2
+return 127
+IW_CNF_EOF
+      )
+      _iw_cnf_body="${_iw_cnf_name}() {
+${_iw_cnf_body}
+}"
+      if eval "$_iw_cnf_body"; then
+        printf '%s\n' "[invoke-wizardry] command_not_found_handler installed (zsh)" >&2
+      else
+        printf '%s\n' "[invoke-wizardry] ERROR: failed to install command_not_found_handler" >&2
+        if [ -n "$_iw_debug_file" ]; then
+          _iw_msg="invoke-wizardry: command_not_found_handler eval failed; dumping body"
+          printf '%s\n' "$_iw_msg" >> "$_iw_debug_file" 2>/dev/null || :
+          printf '%s\n' "$_iw_cnf_body" | nl -ba >> "$_iw_debug_file" 2>/dev/null || :
         fi
-        
-        # Prevent infinite recursion - check if already in handler
-        if [ "${_WIZARDRY_IN_CNF_HANDLER-}" = "1" ]; then
-          if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-            _cnf_file="${HOME-}/.wizardry-debug.log"
-            _cnf_msg="CNF: recursion detected, bailing out"
-            printf '\''%s\n'\'' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-          fi
-          printf '\''%s: command not found\n'\'' "$1" >&2
-          return 127
-        fi
-        _WIZARDRY_IN_CNF_HANDLER=1
-        
-        # Try word-of-binding for autoloading (handles hotloaded spells)
-        _cnf_wob="$WIZARDRY_DIR/spells/.imps/sys/word-of-binding"
-        if [ -n "${WIZARDRY_DIR-}" ] && [ -x "$_cnf_wob" ]; then
-          if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-            _cnf_file="${HOME-}/.wizardry-debug.log"
-            _cnf_msg="CNF: trying word-of-binding for: $1"
-            printf '\''%s\n'\'' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-          fi
-          if "$_cnf_wob" "$@" 2>/dev/null; then
-            if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-              _cnf_file="${HOME-}/.wizardry-debug.log"
-              _cnf_msg="CNF: word-of-binding succeeded for: $1"
-              printf '\''%s\n'\'' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-            fi
-            unset _WIZARDRY_IN_CNF_HANDLER
-            return 0
-          fi
-          if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-            _cnf_file="${HOME-}/.wizardry-debug.log"
-            _cnf_msg="CNF: word-of-binding failed for: $1"
-            printf '\''%s\n'\'' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-          fi
-        fi
-        # Fall back to parse for recursive grammar parsing
-        _cnf_parse="$WIZARDRY_DIR/spells/.imps/lex/parse"
-        if [ -n "${WIZARDRY_DIR-}" ] && [ -x "$_cnf_parse" ]; then
-          if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-            _cnf_file="${HOME-}/.wizardry-debug.log"
-            _cnf_msg="CNF: trying parse for: $1"
-            printf '\''%s\n'\'' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-          fi
-          if "$_cnf_parse" "$@" 2>/dev/null; then
-            if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-              _cnf_file="${HOME-}/.wizardry-debug.log"
-              _cnf_msg="CNF: parse succeeded for: $1"
-              printf '\''%s\n'\'' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-            fi
-            unset _WIZARDRY_IN_CNF_HANDLER
-            return 0
-          fi
-          if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-            _cnf_file="${HOME-}/.wizardry-debug.log"
-            _cnf_msg="CNF: parse failed for: $1"
-            printf '\''%s\n'\'' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-          fi
-        fi
-        # Command truly not found - return 127
-        unset _WIZARDRY_IN_CNF_HANDLER
-        if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-          _cnf_file="${HOME-}/.wizardry-debug.log"
-          _cnf_msg="CNF: command truly not found: $1"
-          printf '\''%s\n'\'' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-        fi
-        printf '\''%s: command not found\n'\'' "$1" >&2
-        return 127
-      }'
+      fi
+      unset _iw_cnf_body _iw_cnf_name
     fi
   else
     printf '%s\n' "[invoke-wizardry] command_not_found_handle NOT installed (disabled)" >&2


### PR DESCRIPTION
### Motivation

- Fix parse errors and fragile quoting when installing the command-not-found hook via `eval` in the `invoke-wizardry` imp.  
- Avoid introducing extra top-level function declarations while still creating shell-specific handlers for Bash and Zsh.  
- Improve diagnostics to make remaining eval/install failures easier to debug.  

### Description

- Reworked CNF installation to build the handler body with an unindented heredoc into `_iw_cnf_body`, wrap it as `$_iw_cnf_name() { ... }`, and `eval` that wrapped body for both `command_not_found_handle` (Bash) and `command_not_found_handler` (Zsh).  
- Removed fragile embedded quoting and heredoc indentation that caused Zsh/Bash parse failures by emitting plain shell code in the heredoc.  
- Added debug diagnostics that dump the constructed eval body to the debug file when the `eval` of the handler body fails.  
- Ensure temporary variables (`_iw_cnf_body` and `_iw_cnf_name`) are unset after installation to avoid leaking state.  

### Testing

- No automated test suite was executed after these changes.  
- Local static inspections and file edits were performed and the change was committed successfully.  
- Recommend running the repository test suite (e.g., the project's existing test runner) to verify the one-function rule and to detect regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c2b484290832094e5d5dccc8bd997)