### PR TITLE
Fix zsh command-not-found handler installation and improve CNF diagnostics

### DIFF
--- a/spells/.imps/sys/invoke-wizardry
+++ b/spells/.imps/sys/invoke-wizardry
@@ -719,164 +719,197 @@ function brace_delta(s, n, m) {
         printf '%s\n' "$_iw_msg" >> "$_iw_debug_file" 2>/dev/null || :
       fi
       # Bash-specific command_not_found_handle
-      eval 'command_not_found_handle() {
-        # Debug logging for command_not_found_handle
-        if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-          _cnf_file="${HOME-}/.wizardry-debug.log"
-          _cnf_msg="CNF: command not found: $1 (args: $*)"
-          printf '\''%s\n'\'' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+      _iw_cnf_name="command_not_found_handle"
+      _iw_cnf_body=$(cat <<'IW_CNF_EOF'
+# Debug logging for command_not_found_handle
+if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+  _cnf_file="${HOME-}/.wizardry-debug.log"
+  _cnf_msg="CNF: command not found: $1 (args: $*)"
+  printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+fi
+
+# Prevent infinite recursion - check if already in handler
+if [ "${_WIZARDRY_IN_CNF_HANDLER-}" = "1" ]; then
+  if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+    _cnf_file="${HOME-}/.wizardry-debug.log"
+    _cnf_msg="CNF: recursion detected, bailing out"
+    printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+  fi
+  printf '%s: command not found\n' "$1" >&2
+  return 127
+fi
+_WIZARDRY_IN_CNF_HANDLER=1
+
+# Try word-of-binding for autoloading (handles hotloaded spells)
+_cnf_wob="$WIZARDRY_DIR/spells/.imps/sys/word-of-binding"
+if [ -n "${WIZARDRY_DIR-}" ] && [ -x "$_cnf_wob" ]; then
+  if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+    _cnf_file="${HOME-}/.wizardry-debug.log"
+    _cnf_msg="CNF: trying word-of-binding for: $1"
+    printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+  fi
+  if "$_cnf_wob" "$@" 2>/dev/null; then
+    if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+      _cnf_file="${HOME-}/.wizardry-debug.log"
+      _cnf_msg="CNF: word-of-binding succeeded for: $1"
+      printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+    fi
+    unset _WIZARDRY_IN_CNF_HANDLER
+    return 0
+  fi
+  if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+    _cnf_file="${HOME-}/.wizardry-debug.log"
+    _cnf_msg="CNF: word-of-binding failed for: $1"
+    printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+  fi
+fi
+# Fall back to parse for recursive grammar parsing
+_cnf_parse="$WIZARDRY_DIR/spells/.imps/lex/parse"
+if [ -n "${WIZARDRY_DIR-}" ] && [ -x "$_cnf_parse" ]; then
+  if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+    _cnf_file="${HOME-}/.wizardry-debug.log"
+    _cnf_msg="CNF: trying parse for: $1"
+    printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+  fi
+  if "$_cnf_parse" "$@" 2>/dev/null; then
+    if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+      _cnf_file="${HOME-}/.wizardry-debug.log"
+      _cnf_msg="CNF: parse succeeded for: $1"
+      printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+    fi
+    unset _WIZARDRY_IN_CNF_HANDLER
+    return 0
+  fi
+  if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+    _cnf_file="${HOME-}/.wizardry-debug.log"
+    _cnf_msg="CNF: parse failed for: $1"
+    printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+  fi
+fi
+# Command truly not found - return 127
+unset _WIZARDRY_IN_CNF_HANDLER
+if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+  _cnf_file="${HOME-}/.wizardry-debug.log"
+  _cnf_msg="CNF: command truly not found: $1"
+  printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+fi
+printf '%s: command not found\n' "$1" >&2
+return 127
+IW_CNF_EOF
+      )
+      _iw_cnf_body="${_iw_cnf_name}() {
+${_iw_cnf_body}
+}"
+      if eval "$_iw_cnf_body"; then
+        printf '%s\n' "[invoke-wizardry] command_not_found_handle installed (bash)" >&2
+      else
+        printf '%s\n' "[invoke-wizardry] ERROR: failed to install command_not_found_handle" >&2
+        if [ -n "$_iw_debug_file" ]; then
+          _iw_msg="invoke-wizardry: command_not_found_handle eval failed; dumping body"
+          printf '%s\n' "$_iw_msg" >> "$_iw_debug_file" 2>/dev/null || :
+          printf '%s\n' "$_iw_cnf_body" | nl -ba >> "$_iw_debug_file" 2>/dev/null || :
         fi
-        
-        # Prevent infinite recursion - check if already in handler
-        if [ "${_WIZARDRY_IN_CNF_HANDLER-}" = "1" ]; then
-          if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-            _cnf_file="${HOME-}/.wizardry-debug.log"
-            _cnf_msg="CNF: recursion detected, bailing out"
-            printf '\''%s\n'\'' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-          fi
-          printf '\''%s: command not found\n'\'' "$1" >&2
-          return 127
-        fi
-        _WIZARDRY_IN_CNF_HANDLER=1
-        
-        # Try word-of-binding for autoloading (handles hotloaded spells)
-        _cnf_wob="$WIZARDRY_DIR/spells/.imps/sys/word-of-binding"
-        if [ -n "${WIZARDRY_DIR-}" ] && [ -x "$_cnf_wob" ]; then
-          if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-            _cnf_file="${HOME-}/.wizardry-debug.log"
-            _cnf_msg="CNF: trying word-of-binding for: $1"
-            printf '\''%s\n'\'' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-          fi
-          if "$_cnf_wob" "$@" 2>/dev/null; then
-            if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-              _cnf_file="${HOME-}/.wizardry-debug.log"
-              _cnf_msg="CNF: word-of-binding succeeded for: $1"
-              printf '\''%s\n'\'' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-            fi
-            unset _WIZARDRY_IN_CNF_HANDLER
-            return 0
-          fi
-          if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-            _cnf_file="${HOME-}/.wizardry-debug.log"
-            _cnf_msg="CNF: word-of-binding failed for: $1"
-            printf '\''%s\n'\'' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-          fi
-        fi
-        # Fall back to parse for recursive grammar parsing
-        _cnf_parse="$WIZARDRY_DIR/spells/.imps/lex/parse"
-        if [ -n "${WIZARDRY_DIR-}" ] && [ -x "$_cnf_parse" ]; then
-          if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-            _cnf_file="${HOME-}/.wizardry-debug.log"
-            _cnf_msg="CNF: trying parse for: $1"
-            printf '\''%s\n'\'' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-          fi
-          if "$_cnf_parse" "$@" 2>/dev/null; then
-            if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-              _cnf_file="${HOME-}/.wizardry-debug.log"
-              _cnf_msg="CNF: parse succeeded for: $1"
-              printf '\''%s\n'\'' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-            fi
-            unset _WIZARDRY_IN_CNF_HANDLER
-            return 0
-          fi
-          if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-            _cnf_file="${HOME-}/.wizardry-debug.log"
-            _cnf_msg="CNF: parse failed for: $1"
-            printf '\''%s\n'\'' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-          fi
-        fi
-        # Command truly not found - return 127
-        unset _WIZARDRY_IN_CNF_HANDLER
-        if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-          _cnf_file="${HOME-}/.wizardry-debug.log"
-          _cnf_msg="CNF: command truly not found: $1"
-          printf '\''%s\n'\'' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-        fi
-        printf '\''%s: command not found\n'\'' "$1" >&2
-        return 127
-      }'
+        printf '%s\n' "[invoke-wizardry] command_not_found_handle eval failed; body dump:" >&2
+        printf '%s\n' "$_iw_cnf_body" | nl -ba >&2
+      fi
+      unset _iw_cnf_body _iw_cnf_name
     elif eval '[ -n "${ZSH_VERSION+x}" ]' 2>/dev/null; then
       if [ -n "$_iw_debug_file" ]; then
         _iw_msg="invoke-wizardry: Zsh detected, installing command_not_found_handler"
         printf '%s\n' "$_iw_msg" >> "$_iw_debug_file" 2>/dev/null || :
       fi
       # Zsh-specific command_not_found_handler
-      eval 'command_not_found_handler() {
-        # Debug logging for command_not_found_handler
-        if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-          _cnf_file="${HOME-}/.wizardry-debug.log"
-          _cnf_msg="CNF: command not found: $1 (args: $*)"
-          printf '\''%s\n'\'' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+      _iw_cnf_name="command_not_found_handler"
+      _iw_cnf_body=$(cat <<'IW_CNF_EOF'
+# Debug logging for command_not_found_handler
+if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+  _cnf_file="${HOME-}/.wizardry-debug.log"
+  _cnf_msg="CNF: command not found: $1 (args: $*)"
+  printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+fi
+
+# Prevent infinite recursion - check if already in handler
+if [ "${_WIZARDRY_IN_CNF_HANDLER-}" = "1" ]; then
+  if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+    _cnf_file="${HOME-}/.wizardry-debug.log"
+    _cnf_msg="CNF: recursion detected, bailing out"
+    printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+  fi
+  printf '%s: command not found\n' "$1" >&2
+  return 127
+fi
+_WIZARDRY_IN_CNF_HANDLER=1
+
+# Try word-of-binding for autoloading (handles hotloaded spells)
+_cnf_wob="$WIZARDRY_DIR/spells/.imps/sys/word-of-binding"
+if [ -n "${WIZARDRY_DIR-}" ] && [ -x "$_cnf_wob" ]; then
+  if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+    _cnf_file="${HOME-}/.wizardry-debug.log"
+    _cnf_msg="CNF: trying word-of-binding for: $1"
+    printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+  fi
+  if "$_cnf_wob" "$@" 2>/dev/null; then
+    if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+      _cnf_file="${HOME-}/.wizardry-debug.log"
+      _cnf_msg="CNF: word-of-binding succeeded for: $1"
+      printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+    fi
+    unset _WIZARDRY_IN_CNF_HANDLER
+    return 0
+  fi
+  if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+    _cnf_file="${HOME-}/.wizardry-debug.log"
+    _cnf_msg="CNF: word-of-binding failed for: $1"
+    printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+  fi
+fi
+# Fall back to parse for recursive grammar parsing
+_cnf_parse="$WIZARDRY_DIR/spells/.imps/lex/parse"
+if [ -n "${WIZARDRY_DIR-}" ] && [ -x "$_cnf_parse" ]; then
+  if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+    _cnf_file="${HOME-}/.wizardry-debug.log"
+    _cnf_msg="CNF: trying parse for: $1"
+    printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+  fi
+  if "$_cnf_parse" "$@" 2>/dev/null; then
+    if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+      _cnf_file="${HOME-}/.wizardry-debug.log"
+      _cnf_msg="CNF: parse succeeded for: $1"
+      printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+    fi
+    unset _WIZARDRY_IN_CNF_HANDLER
+    return 0
+  fi
+  if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+    _cnf_file="${HOME-}/.wizardry-debug.log"
+    _cnf_msg="CNF: parse failed for: $1"
+    printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+  fi
+fi
+# Command truly not found - return 127
+unset _WIZARDRY_IN_CNF_HANDLER
+if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+  _cnf_file="${HOME-}/.wizardry-debug.log"
+  _cnf_msg="CNF: command truly not found: $1"
+  printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+fi
+printf '%s: command not found\n' "$1" >&2
+return 127
+IW_CNF_EOF
+      )
+      if eval "functions[$_iw_cnf_name]=\$_iw_cnf_body"; then
+        printf '%s\n' "[invoke-wizardry] command_not_found_handler installed (zsh)" >&2
+      else
+        printf '%s\n' "[invoke-wizardry] ERROR: failed to install command_not_found_handler" >&2
+        if [ -n "$_iw_debug_file" ]; then
+          _iw_msg="invoke-wizardry: command_not_found_handler eval failed; dumping body"
+          printf '%s\n' "$_iw_msg" >> "$_iw_debug_file" 2>/dev/null || :
+          printf '%s\n' "$_iw_cnf_body" | nl -ba >> "$_iw_debug_file" 2>/dev/null || :
         fi
-        
-        # Prevent infinite recursion - check if already in handler
-        if [ "${_WIZARDRY_IN_CNF_HANDLER-}" = "1" ]; then
-          if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-            _cnf_file="${HOME-}/.wizardry-debug.log"
-            _cnf_msg="CNF: recursion detected, bailing out"
-            printf '\''%s\n'\'' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-          fi
-          printf '\''%s: command not found\n'\'' "$1" >&2
-          return 127
-        fi
-        _WIZARDRY_IN_CNF_HANDLER=1
-        
-        # Try word-of-binding for autoloading (handles hotloaded spells)
-        _cnf_wob="$WIZARDRY_DIR/spells/.imps/sys/word-of-binding"
-        if [ -n "${WIZARDRY_DIR-}" ] && [ -x "$_cnf_wob" ]; then
-          if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-            _cnf_file="${HOME-}/.wizardry-debug.log"
-            _cnf_msg="CNF: trying word-of-binding for: $1"
-            printf '\''%s\n'\'' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-          fi
-          if "$_cnf_wob" "$@" 2>/dev/null; then
-            if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-              _cnf_file="${HOME-}/.wizardry-debug.log"
-              _cnf_msg="CNF: word-of-binding succeeded for: $1"
-              printf '\''%s\n'\'' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-            fi
-            unset _WIZARDRY_IN_CNF_HANDLER
-            return 0
-          fi
-          if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-            _cnf_file="${HOME-}/.wizardry-debug.log"
-            _cnf_msg="CNF: word-of-binding failed for: $1"
-            printf '\''%s\n'\'' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-          fi
-        fi
-        # Fall back to parse for recursive grammar parsing
-        _cnf_parse="$WIZARDRY_DIR/spells/.imps/lex/parse"
-        if [ -n "${WIZARDRY_DIR-}" ] && [ -x "$_cnf_parse" ]; then
-          if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-            _cnf_file="${HOME-}/.wizardry-debug.log"
-            _cnf_msg="CNF: trying parse for: $1"
-            printf '\''%s\n'\'' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-          fi
-          if "$_cnf_parse" "$@" 2>/dev/null; then
-            if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-              _cnf_file="${HOME-}/.wizardry-debug.log"
-              _cnf_msg="CNF: parse succeeded for: $1"
-              printf '\''%s\n'\'' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-            fi
-            unset _WIZARDRY_IN_CNF_HANDLER
-            return 0
-          fi
-          if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-            _cnf_file="${HOME-}/.wizardry-debug.log"
-            _cnf_msg="CNF: parse failed for: $1"
-            printf '\''%s\n'\'' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-          fi
-        fi
-        # Command truly not found - return 127
-        unset _WIZARDRY_IN_CNF_HANDLER
-        if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-          _cnf_file="${HOME-}/.wizardry-debug.log"
-          _cnf_msg="CNF: command truly not found: $1"
-          printf '\''%s\n'\'' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-        fi
-        printf '\''%s: command not found\n'\'' "$1" >&2
-        return 127
-      }'
+        printf '%s\n' "[invoke-wizardry] command_not_found_handler install failed; body dump:" >&2
+        printf '%s\n' "$_iw_cnf_body" | nl -ba >&2
+      fi
+      unset _iw_cnf_body _iw_cnf_name
     fi
   else
     printf '%s\n' "[invoke-wizardry] command_not_found_handle NOT installed (disabled)" >&2


### PR DESCRIPTION
### Motivation
- Avoid Zsh parse failures and fragile quoting when installing the command-not-found handler via `eval`.  
- Make handler installation failures visible immediately by printing constructed handler bodies to stderr for faster debugging.  
- Keep the shell-specific handler construction consistent (heredoc-built bodies) and avoid leaking temporary installation variables.  
- Resolve a merge conflict and address inline comments about the Zsh installation path.

### Description
- Build CNF handler bodies with a `cat <<'IW_CNF_EOF'` heredoc into `_iw_cnf_body` and wrap as `$_iw_cnf_name() { ... }` for Bash.  
- Install the Zsh handler by assigning `functions[$_iw_cnf_name]=".$_iw_cnf_body"` instead of `eval` to avoid Zsh eval/quoting problems.  
- Emit stderr dumps of the constructed handler body on install failure (in addition to writing to the debug file) to make diagnostics immediately visible.  
- Ensure temporary variables `_iw_cnf_body` and `_iw_cnf_name` are unset after installation to avoid leaking state.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c2b484290832094e5d5dccc8bd997)