### PR TITLE
Fix zsh command-not-found handler install

### DIFF
--- a/spells/.imps/sys/invoke-wizardry
+++ b/spells/.imps/sys/invoke-wizardry
@@ -897,7 +897,10 @@ printf '%s: command not found\n' "$1" >&2
 return 127
 IW_CNF_EOF
       )
-      if eval "functions[$_iw_cnf_name]=\$_iw_cnf_body"; then
+      _iw_cnf_body="${_iw_cnf_name}() {
+${_iw_cnf_body}
+}"
+      if eval "$_iw_cnf_body"; then
         printf '%s\n' "[invoke-wizardry] command_not_found_handler installed (zsh)" >&2
       else
         printf '%s\n' "[invoke-wizardry] ERROR: failed to install command_not_found_handler" >&2


### PR DESCRIPTION
### Motivation
- Zsh startup could fail with parse errors when installing the command-not-found handler, which could break new terminal windows.
- The zsh path previously attempted to assign a heredoc body into `functions[...]`, producing an invalid function definition in some environments.
- The change aims to reliably install a `command_not_found_handler` in zsh without causing parse-time failures during shell initialization.
- Keep the installation approach consistent with the bash handler to ensure hotloading and debugging behavior remains intact.

### Description
- Wrap the heredoc body into a proper zsh function definition by setting `_iw_cnf_body="${_iw_cnf_name}() { ... }"` before evaluating it.
- Replace the previous `functions[$_iw_cnf_name]=_iw_cnf_body` assignment attempt with `eval "$ _iw_cnf_body"` to avoid invalid function syntax.
- Preserve existing debug logging and error-dump behavior if the eval fails.
- The change modifies `spells/.imps/sys/invoke-wizardry` around the zsh `command_not_found_handler` installation logic.

### Testing
- No automated tests were run for this shell-script-only change.
- The patch is limited to handler installation logic and does not alter other runtime behavior.
- Manual verification in zsh is recommended to confirm startup no longer produces the previous parse error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c40fa1f7c83208f024507d6164c92)