### PR TITLE
Fix zsh command-not-found handler install

### DIFF
--- a/spells/.imps/sys/invoke-wizardry
+++ b/spells/.imps/sys/invoke-wizardry
@@ -897,7 +897,10 @@ printf '%s: command not found\n' "$1" >&2
 return 127
 IW_CNF_EOF
       )
-      if functions["$_iw_cnf_name"]="$_iw_cnf_body"; then
+      _iw_cnf_body="${_iw_cnf_name}() {
+${_iw_cnf_body}
+}"
+      if eval "$_iw_cnf_body"; then
         printf '%s\n' "[invoke-wizardry] command_not_found_handler installed (zsh)" >&2
       else
         printf '%s\n' "[invoke-wizardry] ERROR: failed to install command_not_found_handler" >&2


### PR DESCRIPTION
### Motivation

- Zsh shells were failing with parse errors and `invalid function definition` when `invoke-wizardry` tried to install the command-not-found handler. 
- The handler install used an approach that produced an invalid function definition in zsh, causing new terminal windows to immediately terminate (`[Process completed]`).

### Description

- Replace the broken zsh installation path that attempted `functions["$_iw_cnf_name"]="$_iw_cnf_body"` with a wrapped function definition string. 
- Build the handler body as `"${_iw_cnf_name}() { ... }"` and create the function via `eval "$ _iw_cnf_body"` so zsh parses it correctly. 
- Change applied in `spells/.imps/sys/invoke-wizardry` to reliably install `command_not_found_handler` under zsh. 

### Testing

- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ce61d2da083208dcf6d3d46299a23)