### PR TITLE
Define zsh command_not_found_handler directly to avoid eval parse errors

### DIFF
--- a/spells/.imps/sys/invoke-wizardry
+++ b/spells/.imps/sys/invoke-wizardry
@@ -819,97 +819,83 @@ ${_iw_cnf_body}
         printf '%s\n' "$_iw_msg" >> "$_iw_debug_file" 2>/dev/null || :
       fi
       # Zsh-specific command_not_found_handler
-      _iw_cnf_name="command_not_found_handler"
-      _iw_cnf_body=$(cat <<'IW_CNF_EOF'
-# Debug logging for command_not_found_handler
-if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-  _cnf_file="${HOME-}/.wizardry-debug.log"
-  _cnf_msg="CNF: command not found: $1 (args: $*)"
-  printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-fi
-
-# Prevent infinite recursion - check if already in handler
-if [ "${_WIZARDRY_IN_CNF_HANDLER-}" = "1" ]; then
-  if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-    _cnf_file="${HOME-}/.wizardry-debug.log"
-    _cnf_msg="CNF: recursion detected, bailing out"
-    printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-  fi
-  printf '%s: command not found\n' "$1" >&2
-  return 127
-fi
-_WIZARDRY_IN_CNF_HANDLER=1
-
-# Try word-of-binding for autoloading (handles hotloaded spells)
-_cnf_wob="$WIZARDRY_DIR/spells/.imps/sys/word-of-binding"
-if [ -n "${WIZARDRY_DIR-}" ] && [ -x "$_cnf_wob" ]; then
-  if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-    _cnf_file="${HOME-}/.wizardry-debug.log"
-    _cnf_msg="CNF: trying word-of-binding for: $1"
-    printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-  fi
-  if "$_cnf_wob" "$@" 2>/dev/null; then
-    if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-      _cnf_file="${HOME-}/.wizardry-debug.log"
-      _cnf_msg="CNF: word-of-binding succeeded for: $1"
-      printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-    fi
-    unset _WIZARDRY_IN_CNF_HANDLER
-    return 0
-  fi
-  if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-    _cnf_file="${HOME-}/.wizardry-debug.log"
-    _cnf_msg="CNF: word-of-binding failed for: $1"
-    printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-  fi
-fi
-# Fall back to parse for recursive grammar parsing
-_cnf_parse="$WIZARDRY_DIR/spells/.imps/lex/parse"
-if [ -n "${WIZARDRY_DIR-}" ] && [ -x "$_cnf_parse" ]; then
-  if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-    _cnf_file="${HOME-}/.wizardry-debug.log"
-    _cnf_msg="CNF: trying parse for: $1"
-    printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-  fi
-  if "$_cnf_parse" "$@" 2>/dev/null; then
-    if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-      _cnf_file="${HOME-}/.wizardry-debug.log"
-      _cnf_msg="CNF: parse succeeded for: $1"
-      printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-    fi
-    unset _WIZARDRY_IN_CNF_HANDLER
-    return 0
-  fi
-  if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-    _cnf_file="${HOME-}/.wizardry-debug.log"
-    _cnf_msg="CNF: parse failed for: $1"
-    printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-  fi
-fi
-# Command truly not found - return 127
-unset _WIZARDRY_IN_CNF_HANDLER
-if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
-  _cnf_file="${HOME-}/.wizardry-debug.log"
-  _cnf_msg="CNF: command truly not found: $1"
-  printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
-fi
-printf '%s: command not found\n' "$1" >&2
-return 127
-IW_CNF_EOF
-      )
-      if functions["$_iw_cnf_name"]="$_iw_cnf_body"; then
-        printf '%s\n' "[invoke-wizardry] command_not_found_handler installed (zsh)" >&2
-      else
-        printf '%s\n' "[invoke-wizardry] ERROR: failed to install command_not_found_handler" >&2
-        if [ -n "$_iw_debug_file" ]; then
-          _iw_msg="invoke-wizardry: command_not_found_handler eval failed; dumping body"
-          printf '%s\n' "$_iw_msg" >> "$_iw_debug_file" 2>/dev/null || :
-          printf '%s\n' "$_iw_cnf_body" | nl -ba >> "$_iw_debug_file" 2>/dev/null || :
+      command_not_found_handler() {
+        # Debug logging for command_not_found_handler
+        if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+          _cnf_file="${HOME-}/.wizardry-debug.log"
+          _cnf_msg="CNF: command not found: $1 (args: $*)"
+          printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
         fi
-        printf '%s\n' "[invoke-wizardry] command_not_found_handler install failed; body dump:" >&2
-        printf '%s\n' "$_iw_cnf_body" | nl -ba >&2
-      fi
-      unset _iw_cnf_body _iw_cnf_name
+
+        # Prevent infinite recursion - check if already in handler
+        if [ "${_WIZARDRY_IN_CNF_HANDLER-}" = "1" ]; then
+          if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+            _cnf_file="${HOME-}/.wizardry-debug.log"
+            _cnf_msg="CNF: recursion detected, bailing out"
+            printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+          fi
+          printf '%s: command not found\n' "$1" >&2
+          return 127
+        fi
+        _WIZARDRY_IN_CNF_HANDLER=1
+
+        # Try word-of-binding for autoloading (handles hotloaded spells)
+        _cnf_wob="$WIZARDRY_DIR/spells/.imps/sys/word-of-binding"
+        if [ -n "${WIZARDRY_DIR-}" ] && [ -x "$_cnf_wob" ]; then
+          if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+            _cnf_file="${HOME-}/.wizardry-debug.log"
+            _cnf_msg="CNF: trying word-of-binding for: $1"
+            printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+          fi
+          if "$_cnf_wob" "$@" 2>/dev/null; then
+            if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+              _cnf_file="${HOME-}/.wizardry-debug.log"
+              _cnf_msg="CNF: word-of-binding succeeded for: $1"
+              printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+            fi
+            unset _WIZARDRY_IN_CNF_HANDLER
+            return 0
+          fi
+          if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+            _cnf_file="${HOME-}/.wizardry-debug.log"
+            _cnf_msg="CNF: word-of-binding failed for: $1"
+            printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+          fi
+        fi
+        # Fall back to parse for recursive grammar parsing
+        _cnf_parse="$WIZARDRY_DIR/spells/.imps/lex/parse"
+        if [ -n "${WIZARDRY_DIR-}" ] && [ -x "$_cnf_parse" ]; then
+          if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+            _cnf_file="${HOME-}/.wizardry-debug.log"
+            _cnf_msg="CNF: trying parse for: $1"
+            printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+          fi
+          if "$_cnf_parse" "$@" 2>/dev/null; then
+            if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+              _cnf_file="${HOME-}/.wizardry-debug.log"
+              _cnf_msg="CNF: parse succeeded for: $1"
+              printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+            fi
+            unset _WIZARDRY_IN_CNF_HANDLER
+            return 0
+          fi
+          if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+            _cnf_file="${HOME-}/.wizardry-debug.log"
+            _cnf_msg="CNF: parse failed for: $1"
+            printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+          fi
+        fi
+        # Command truly not found - return 127
+        unset _WIZARDRY_IN_CNF_HANDLER
+        if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+          _cnf_file="${HOME-}/.wizardry-debug.log"
+          _cnf_msg="CNF: command truly not found: $1"
+          printf '%s\n' "$_cnf_msg" >> "$_cnf_file" 2>/dev/null || :
+        fi
+        printf '%s: command not found\n' "$1" >&2
+        return 127
+      }
+      printf '%s\n' "[invoke-wizardry] command_not_found_handler installed (zsh)" >&2
     fi
   else
     printf '%s\n' "[invoke-wizardry] command_not_found_handle NOT installed (disabled)" >&2


### PR DESCRIPTION
### Motivation
- Zsh was failing with a parse error (e.g. "parse error near `fi`") when the command-not-found handler was installed via `eval` or `functions[...]`, causing new shells to terminate. 
- The prior implementation built the handler as a string and attempted to create it dynamically, which produced invalid zsh syntax. 
- The intent is to reliably install `command_not_found_handler` under zsh without introducing parse-and-eval fragility. 
- Preserve the handler behavior while making installation robust for zsh.

### Description
- Replace the eval/`functions[...]`-based install path with a direct `command_not_found_handler()` function definition in `spells/.imps/sys/invoke-wizardry` for zsh. 
- Keep the existing handler logic intact including debug logging, recursion protection, word-of-binding autoloading, parse fallback, and return semantics. 
- Emit `"[invoke-wizardry] command_not_found_handler installed (zsh)"` after the function definition to confirm successful installation. 
- Remove the dynamic body construction, eval path, and associated debug-dump logic that previously attempted to create the function at runtime.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ce61d2da083208dcf6d3d46299a23)