### PR TITLE
Fix spell category hidden-directory detection

### DIFF
--- a/spells/.imps/sys/invoke-wizardry
+++ b/spells/.imps/sys/invoke-wizardry
@@ -390,20 +390,19 @@ function brace_delta(s, n, m) {
     # POSIX-compliant: Skip if glob didn't match (returns literal pattern)
     [ -e "$_iw_spell_cat" ] || continue
     [ -d "$_iw_spell_cat" ] || continue
+    _iw_spell_cat_name=$(basename "$_iw_spell_cat")
     # Skip hidden directories (like .imps and .arcana)
-    case "$_iw_spell_cat" in
-      */.*) 
-        printf '%s\n' "[invoke-wizardry] Skipping hidden directory: $(basename "$_iw_spell_cat")" >&2
+    case "$_iw_spell_cat_name" in
+      .* )
+        printf '%s\n' "[invoke-wizardry] Skipping hidden directory: $_iw_spell_cat_name" >&2
         if [ -n "$_iw_debug_file" ]; then
-          _iw_msg="Skipping hidden directory: $(basename "$_iw_spell_cat")"
+          _iw_msg="Skipping hidden directory: $_iw_spell_cat_name"
           _iw_full="invoke-wizardry: $_iw_msg"
           printf '%s\n' "$_iw_full" >> "$_iw_debug_file" 2>/dev/null || :
         fi
-        continue 
+        continue
         ;;
     esac
-    
-    _iw_spell_cat_name=$(basename "$_iw_spell_cat")
     printf '%s\n' "[invoke-wizardry] Processing category: $_iw_spell_cat_name" >&2
     printf '%s\n' "[invoke-wizardry] Processing category: $_iw_spell_cat_name" >&2
     if [ -n "$_iw_debug_file" ]; then


### PR DESCRIPTION
### Motivation
- The hidden-directory check used the full category path which could match intermediate path components like `.wizardry`, causing every spell category to be treated as hidden. 
- That behavior resulted in `Spell sourcing complete: total=0` and missing spells such as `menu` because categories were skipped incorrectly. 
- The intent is to skip only directories whose basename begins with a dot (e.g. `.imps`, `.arcana`) while allowing normal categories to be processed. 

### Description
- Compute `_iw_spell_cat_name` with `basename` before the hidden-dir check and use it in the `case` statement so only the basename is inspected. 
- Change the `case` pattern to `.*` and update debug messages to reference `_iw_spell_cat_name` instead of recomputing `basename`. 
- Remove the old `case` that matched against the full path and relocate the basename assignment earlier in the loop to avoid false positives. 

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d32c4325c8320b942ac074665c9b4)