### PR TITLE
Send invoke-wizardry debug logs to stderr and surface spell eval errors

### DIFF
--- a/spells/.imps/sys/invoke-wizardry
+++ b/spells/.imps/sys/invoke-wizardry
@@ -36,16 +36,10 @@ printf '%s\n' "[invoke-wizardry] Permissive mode set" >&2
 printf '%s\n' "[invoke-wizardry] Starting (unconditional diagnostic output enabled)" >&2
 
 # Debug logging support - set WIZARDRY_DEBUG=1 to enable detailed logging
-# Logs go to ~/.wizardry-debug.log to avoid interfering with terminal
-# Set up debug file path once
-if [ "${WIZARDRY_DEBUG-}" = "1" ] && [ -n "${HOME-}" ]; then
-  _iw_debug_file="$HOME/.wizardry-debug.log"
-  # Write a marker immediately to confirm logging is working
-  # Use printf directly without date to avoid potential hangs
-  printf '%s\n' "=== invoke-wizardry: DEBUG LOGGING ENABLED ===" >> "$_iw_debug_file" 2>/dev/null || :
-  printf '%s\n' "HOME=$HOME" >> "$_iw_debug_file" 2>/dev/null || :
-  printf '%s\n' "WIZARDRY_DEBUG=$WIZARDRY_DEBUG" >> "$_iw_debug_file" 2>/dev/null || :
-  printf '%s\n' "[invoke-wizardry] Debug file: $_iw_debug_file" >&2
+# Logs go to stderr to keep output in the terminal.
+if [ "${WIZARDRY_DEBUG-}" = "1" ]; then
+  _iw_debug_file="/dev/stderr"
+  printf '%s\n' "[invoke-wizardry] Debug logging enabled (stderr)" >&2
 else
   _iw_debug_file=""
   printf '%s\n' "[invoke-wizardry] Debug logging disabled" >&2
@@ -390,20 +384,19 @@ function brace_delta(s, n, m) {
     # POSIX-compliant: Skip if glob didn't match (returns literal pattern)
     [ -e "$_iw_spell_cat" ] || continue
     [ -d "$_iw_spell_cat" ] || continue
+    _iw_spell_cat_name=$(basename "$_iw_spell_cat")
     # Skip hidden directories (like .imps and .arcana)
-    case "$_iw_spell_cat" in
-      */.*) 
-        printf '%s\n' "[invoke-wizardry] Skipping hidden directory: $(basename "$_iw_spell_cat")" >&2
+    case "$_iw_spell_cat_name" in
+      .* )
+        printf '%s\n' "[invoke-wizardry] Skipping hidden directory: $_iw_spell_cat_name" >&2
         if [ -n "$_iw_debug_file" ]; then
-          _iw_msg="Skipping hidden directory: $(basename "$_iw_spell_cat")"
+          _iw_msg="Skipping hidden directory: $_iw_spell_cat_name"
           _iw_full="invoke-wizardry: $_iw_msg"
           printf '%s\n' "$_iw_full" >> "$_iw_debug_file" 2>/dev/null || :
         fi
-        continue 
+        continue
         ;;
     esac
-    
-    _iw_spell_cat_name=$(basename "$_iw_spell_cat")
     printf '%s\n' "[invoke-wizardry] Processing category: $_iw_spell_cat_name" >&2
     printf '%s\n' "[invoke-wizardry] Processing category: $_iw_spell_cat_name" >&2
     if [ -n "$_iw_debug_file" ]; then
@@ -477,11 +470,14 @@ function brace_delta(s, n, m) {
 } # awk: end program
 ' "$_iw_spell"); then
           if [ -n "$_iw_spell_body" ]; then
-            if ! eval "$_iw_spell_body" 2>/dev/null; then
+            if ! _iw_spell_error=$(eval "$_iw_spell_body" 2>&1); then
               _iw_spell_failed=$((_iw_spell_failed + 1))
               if [ -n "$_iw_debug_file" ]; then
                 _iw_msg="invoke-wizardry: ✗ Failed to source spell: $_iw_spell_name"
                 printf '%s\n' "$_iw_msg" >> "$_iw_debug_file" 2>/dev/null || :
+                if [ -n "$_iw_spell_error" ]; then
+                  printf '%s\n' "invoke-wizardry:   error: $_iw_spell_error" >> "$_iw_debug_file" 2>/dev/null || :
+                fi
               fi
               continue
             fi
@@ -525,6 +521,11 @@ function brace_delta(s, n, m) {
   if [ -n "$_iw_debug_file" ]; then
     _iw_msg="invoke-wizardry: Spell sourcing complete: $_iw_spell_summary"
     printf '%s\n' "$_iw_msg" >> "$_iw_debug_file" 2>/dev/null || :
+    if command -v menu >/dev/null 2>&1; then
+      printf '%s\n' "invoke-wizardry: Debug: menu spell is available" >> "$_iw_debug_file" 2>/dev/null || :
+    else
+      printf '%s\n' "invoke-wizardry: Debug: menu spell NOT found after loading" >> "$_iw_debug_file" 2>/dev/null || :
+    fi
   fi
   
   printf '%s\n' "[invoke-wizardry] Checking for user spells" >&2


### PR DESCRIPTION
### Motivation
- Keep diagnostic output visible in-terminal instead of writing to ~/.wizardry-debug.log to simplify debugging when copying terminal output. 
- Make failures that occur while sourcing spell files visible by capturing and reporting eval error output. 
- Aid investigation of missing spells (e.g. `menu`) by adding an explicit availability check after spell loading. 
- Avoid skipping valid categories by ensuring the hidden-directory check inspects the category basename.

### Description
- Change debug logging to use stderr when `WIZARDRY_DEBUG=1` by setting `_iw_debug_file` to `/dev/stderr` and otherwise disabling file output. 
- Capture stderr from `eval` when sourcing a spell into `_iw_spell_error` and log the error text to the debug output when sourcing fails. 
- Add a post-load diagnostic that checks `command -v menu` and reports whether the `menu` spell was found after spell sourcing. 
- Compute `_iw_spell_cat_name` earlier and switch the hidden-directory check to examine the basename so only directories whose name begins with a dot are skipped.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694d32c4325c8320b942ac074665c9b4)