### PR TITLE
Fix imp family glob expansion in invoke-wizardry

### DIFF
--- a/spells/.imps/sys/invoke-wizardry
+++ b/spells/.imps/sys/invoke-wizardry
@@ -279,15 +279,16 @@ _invoke_wizardry() {
     if [ -n "$_iw_debug_file" ]; then
       printf '%s\n' "[invoke-wizardry] Imp directory exists, starting family loop" >&2
     fi
-    _iw_imp_family_globs="$_iw_imps_dir/*"
     if [ "$_iw_non_interactive" -eq 1 ] && [ "${WIZARDRY_LOAD_ALL-}" != "1" ]; then
-      _iw_imp_family_globs="$_iw_imps_dir/cond $_iw_imps_dir/out $_iw_imps_dir/sys"
+      set -- "$_iw_imps_dir/cond" "$_iw_imps_dir/out" "$_iw_imps_dir/sys"
       if [ -n "$_iw_debug_file" ]; then
         _iw_msg="invoke-wizardry: Non-interactive shell detected; loading minimal imp families"
         printf '%s\n' "$_iw_msg" >> "$_iw_debug_file" 2>/dev/null || :
       fi
+    else
+      set -- "$_iw_imps_dir"/*
     fi
-    for _iw_family in $_iw_imp_family_globs; do
+    for _iw_family in "$@"; do
       if [ -n "$_iw_debug_file" ]; then
         printf '%s\n' "[invoke-wizardry] Checking family: $_iw_family" >&2
       fi


### PR DESCRIPTION
### Motivation
- The imp loader failed to expand the imp-family glob when stored in a variable, causing some sys imps (notably `require-wizardry`) to never be sourced and resulting in `command not found` errors.
- This prevented core initialization and caused interactive shells to prematurely exit with `[Process completed]` in the terminal.
- The intent is to ensure imp family paths are enumerated correctly in both interactive and non-interactive shells.
- Preserve the existing minimal-family behavior for non-interactive shells while fixing glob expansion.

### Description
- Replace the `_iw_imp_family_globs` variable approach with `set --` to populate positional parameters so shell globbing is expanded immediately (using `set -- "$_iw_imps_dir"/*`).
- Keep the non-interactive minimal family selection by setting `set -- "$_iw_imps_dir/cond" "$ _iw_imps_dir/out" "$ _iw_imps_dir/sys"` when appropriate.
- Iterate over the expanded list via `for _iw_family in "$@"; do` so each imp family directory is processed reliably.
- This ensures `spells/.imps/sys/require-wizardry` and other imps are discovered and sourced.

### Testing
- No automated tests were run for this change.
- The change was applied and committed to the repository without running CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e86df408c8320bca34187b4983743)