### PR TITLE
Fix zsh-friendly tty state capture in menu spell

### DIFF
--- a/spells/cantrips/menu
+++ b/spells/cantrips/menu
@@ -46,7 +46,9 @@ if [ ! -r "$menu_tty" ] || [ ! -w "$menu_tty" ]; then
         die "menu: unable to access controlling terminal '$menu_tty'" || return 1
 fi
 
-if ! menu_saved_tty_state=$(stty -g <"$menu_tty" 2>/dev/null); then
+if menu_saved_tty_state=$(stty -g <"$menu_tty" 2>/dev/null); then
+        :
+else
         die "menu: unable to read terminal settings" || return 1
 fi
 


### PR DESCRIPTION
### Motivation
- Opening a new zsh interactive shell produced a parse error that prevented the `menu` spell from being loaded, leaving `menu` and related commands unavailable.
- The root cause was a negated assignment pattern `if ! var=$(...)` which can trigger parsing errors when the script is sourced by zsh.
- The change aims to preserve the original runtime error handling while avoiding zsh parser edge cases.

### Description
- Replace the negated-assignment `if ! menu_saved_tty_state=$(stty -g <"$menu_tty" 2>/dev/null); then` with a zsh-safe conditional that assigns and branches: `if menu_saved_tty_state=$(stty -g ...); then :; else die ...; fi`.
- Keep the same failure behavior (call `die` and return non-zero) when `stty` cannot read the tty state.
- Change is localized to the `spells/cantrips/menu` file and does not alter other logic.

### Testing
- Ran a POSIX syntax check with `sh -n spells/cantrips/menu`, which completed successfully.
- No parse error occurred after the change when validating the `menu` script source.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e8aa7b8cc8320854d3e817d279a6d)