### PR TITLE
Source word-of-binding in command-not-found handler

### DIFF
--- a/spells/.imps/sys/invoke-wizardry
+++ b/spells/.imps/sys/invoke-wizardry
@@ -216,8 +216,14 @@ function brace_delta(s, n, m) {
       
       # Try word-of-binding
       _cnf_wob="$WIZARDRY_DIR/spells/.imps/sys/word-of-binding"
-      if [ -n "${WIZARDRY_DIR-}" ] && [ -x "$_cnf_wob" ]; then
-        if "$_cnf_wob" "$@" 2>/dev/null; then
+      if [ -n "${WIZARDRY_DIR-}" ] && [ -r "$_cnf_wob" ]; then
+        if [ "${_WIZARDRY_WOB_LOADED-}" != "1" ]; then
+          WIZARDRY_SOURCE_WORD_OF_BINDING=1 . "$_cnf_wob" 2>/dev/null || :
+          unset WIZARDRY_SOURCE_WORD_OF_BINDING
+          _WIZARDRY_WOB_LOADED=1
+          export _WIZARDRY_WOB_LOADED
+        fi
+        if command -v _word_of_binding >/dev/null 2>&1 && _word_of_binding "$@" 2>/dev/null; then
           unset _WIZARDRY_IN_CNF
           return 0
         fi
@@ -241,8 +247,14 @@ function brace_delta(s, n, m) {
       
       # Try word-of-binding
       _cnf_wob="$WIZARDRY_DIR/spells/.imps/sys/word-of-binding"
-      if [ -n "${WIZARDRY_DIR-}" ] && [ -x "$_cnf_wob" ]; then
-        if "$_cnf_wob" "$@" 2>/dev/null; then
+      if [ -n "${WIZARDRY_DIR-}" ] && [ -r "$_cnf_wob" ]; then
+        if [ "${_WIZARDRY_WOB_LOADED-}" != "1" ]; then
+          WIZARDRY_SOURCE_WORD_OF_BINDING=1 . "$_cnf_wob" 2>/dev/null || :
+          unset WIZARDRY_SOURCE_WORD_OF_BINDING
+          _WIZARDRY_WOB_LOADED=1
+          export _WIZARDRY_WOB_LOADED
+        fi
+        if command -v _word_of_binding >/dev/null 2>&1 && _word_of_binding "$@" 2>/dev/null; then
           unset _WIZARDRY_IN_CNF
           return 0
         fi

--- a/spells/.imps/sys/word-of-binding
+++ b/spells/.imps/sys/word-of-binding
@@ -2,7 +2,10 @@
 # word-of-binding NAME [ARGS...] - resolve and invoke a wizardry command by name
 # Dispatcher for autoloading missing commands.
 # Sources the module and calls its true-name function.
-set -eu
+# NOTE: Avoid changing shell options when sourced into an interactive shell.
+if [ "${WIZARDRY_SOURCE_WORD_OF_BINDING-}" != "1" ]; then
+  set -eu
+fi
 
 _word_of_binding() {
   if [ $# -eq 0 ]; then


### PR DESCRIPTION
### Motivation

- Fix the failure where `menu` (and other spells) were not available in a fresh interactive shell after installation. 
- Prevent `word-of-binding` from changing shell options when it is sourced into an interactive shell. 
- Ensure hotloaded spells are bound into the current shell (not only executed in a subshell) so future calls work without restarting the shell.

### Description

- Guarded `set -eu` in `spells/.imps/sys/word-of-binding` so it does not modify shell options when the file is sourced via `WIZARDRY_SOURCE_WORD_OF_BINDING=1`.
- Changed `spells/.imps/sys/invoke-wizardry` command-not-found handlers (bash and zsh) to `source` the `word-of-binding` file once with `WIZARDRY_SOURCE_WORD_OF_BINDING=1` and set a `_WIZARDRY_WOB_LOADED` flag so `_word_of_binding` is available in the interactive shell.
- After sourcing, the handlers now call the bound function `_word_of_binding` (if present) instead of attempting to execute the `word-of-binding` file as a detached program, and they check readability (`-r`) rather than executability (`-x`).
- The change is applied symmetrically to both `command_not_found_handle` (bash) and `command_not_found_handler` (zsh).

### Testing

- Sourced `spells/.imps/sys/invoke-wizardry` in a non-login bash instance and ran `type menu` which reported `menu` is a function and returned status 0, indicating the preloaded `menu` binding is available (success).
- No additional automated test suite was executed beyond the shell invocation checks above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950eaebc9748320a6b235068c3d4488)