### PR TITLE
Fix zsh preloading of essential spells

### DIFF
--- a/spells/.imps/sys/invoke-wizardry
+++ b/spells/.imps/sys/invoke-wizardry
@@ -166,8 +166,18 @@ function brace_delta(s, n, m) {
   # Pre-load essential imps needed by menu
   # These are from sys/, out/, fs/, cond/ families
   _iw_debug "Pre-loading essential imps"
-  _iw_essential_imps="require require-wizardry castable env-clear temp-file cleanup-file has die warn fail say"
-  for _imp_name in $_iw_essential_imps; do
+  for _imp_name in \
+    require \
+    require-wizardry \
+    castable \
+    env-clear \
+    temp-file \
+    cleanup-file \
+    has \
+    die \
+    warn \
+    fail \
+    say; do
     # Search for imp in all families
     for _family_dir in "$WIZARDRY_DIR"/spells/.imps/*; do
       [ -d "$_family_dir" ] || continue
@@ -181,8 +191,14 @@ function brace_delta(s, n, m) {
   
   # Pre-load menu and its helper spell dependencies
   _iw_debug "Pre-loading essential spells"
-  _iw_essential_spells="menu await-keypress move-cursor fathom-cursor fathom-terminal cursor-blink colors"
-  for _spell_name in $_iw_essential_spells; do
+  for _spell_name in \
+    menu \
+    await-keypress \
+    move-cursor \
+    fathom-cursor \
+    fathom-terminal \
+    cursor-blink \
+    colors; do
     # Search for spell in all categories
     for _spell_dir in "$WIZARDRY_DIR"/spells/*; do
       [ -d "$_spell_dir" ] || continue
@@ -216,8 +232,14 @@ function brace_delta(s, n, m) {
       
       # Try word-of-binding
       _cnf_wob="$WIZARDRY_DIR/spells/.imps/sys/word-of-binding"
-      if [ -n "${WIZARDRY_DIR-}" ] && [ -x "$_cnf_wob" ]; then
-        if "$_cnf_wob" "$@" 2>/dev/null; then
+      if [ -n "${WIZARDRY_DIR-}" ] && [ -r "$_cnf_wob" ]; then
+        if [ "${_WIZARDRY_WOB_LOADED-}" != "1" ]; then
+          WIZARDRY_SOURCE_WORD_OF_BINDING=1 . "$_cnf_wob" 2>/dev/null || :
+          unset WIZARDRY_SOURCE_WORD_OF_BINDING
+          _WIZARDRY_WOB_LOADED=1
+          export _WIZARDRY_WOB_LOADED
+        fi
+        if command -v _word_of_binding >/dev/null 2>&1 && _word_of_binding "$@" 2>/dev/null; then
           unset _WIZARDRY_IN_CNF
           return 0
         fi
@@ -241,8 +263,14 @@ function brace_delta(s, n, m) {
       
       # Try word-of-binding
       _cnf_wob="$WIZARDRY_DIR/spells/.imps/sys/word-of-binding"
-      if [ -n "${WIZARDRY_DIR-}" ] && [ -x "$_cnf_wob" ]; then
-        if "$_cnf_wob" "$@" 2>/dev/null; then
+      if [ -n "${WIZARDRY_DIR-}" ] && [ -r "$_cnf_wob" ]; then
+        if [ "${_WIZARDRY_WOB_LOADED-}" != "1" ]; then
+          WIZARDRY_SOURCE_WORD_OF_BINDING=1 . "$_cnf_wob" 2>/dev/null || :
+          unset WIZARDRY_SOURCE_WORD_OF_BINDING
+          _WIZARDRY_WOB_LOADED=1
+          export _WIZARDRY_WOB_LOADED
+        fi
+        if command -v _word_of_binding >/dev/null 2>&1 && _word_of_binding "$@" 2>/dev/null; then
           unset _WIZARDRY_IN_CNF
           return 0
         fi

--- a/spells/.imps/sys/word-of-binding
+++ b/spells/.imps/sys/word-of-binding
@@ -2,7 +2,10 @@
 # word-of-binding NAME [ARGS...] - resolve and invoke a wizardry command by name
 # Dispatcher for autoloading missing commands.
 # Sources the module and calls its true-name function.
-set -eu
+# NOTE: Avoid changing shell options when sourced into an interactive shell.
+if [ "${WIZARDRY_SOURCE_WORD_OF_BINDING-}" != "1" ]; then
+  set -eu
+fi
 
 _word_of_binding() {
   if [ $# -eq 0 ]; then


### PR DESCRIPTION
### Motivation
- Zsh was treating the space-separated imp/spell lists as a single word which prevented preloading of essential helpers in zsh shells. 
- As a result commands like `menu` were not available in fresh interactive shells without restarting the shell. 
- Previously `word-of-binding` could mutate shell options when sourced, and the command-not-found handlers needed to make the bound `_word_of_binding` function available in the interactive shell. 

### Description
- Iterate the essential imp and spell names with explicit multi-line word lists in `spells/.imps/sys/invoke-wizardry` so zsh performs the expected word-splitting and each name is loaded. 
- Make the command-not-found handlers (bash and zsh) source `spells/.imps/sys/word-of-binding` once under `WIZARDRY_SOURCE_WORD_OF_BINDING=1`, set `_WIZARDRY_WOB_LOADED`, check readability with `-r`, and invoke the bound `_word_of_binding` function via `command -v _word_of_binding`. 
- Guard `set -eu` in `spells/.imps/sys/word-of-binding` so it only changes shell options when the script is executed and not when it is sourced into an interactive shell. 

### Testing
- Manually sourced `spells/.imps/sys/invoke-wizardry` in a non-login `bash` instance and ran `type menu`, which reported `menu` is a function (success). 
- The failure case where `menu` was not found in `zsh` was observed prior to this fix and motivated the change to explicit word lists. 
- No automated test suite was executed after the latest change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950eaebc9748320a6b235068c3d4488)