### PR TITLE
Fix menu color loading when `colors` is preloaded

### DIFF
--- a/.github/SPIRAL_DEBUG.md
+++ b/.github/SPIRAL_DEBUG.md
@@ -113,6 +113,12 @@ After all features work:
   - ✅ menu --help works immediately
 - **Next**: User will manually test in real terminal before Phase 2
 
+### 2025-12-28: Fix menu colors loading when colors is preloaded
+
+- **Issue**: menu was calling `. colors` when `colors` was preloaded as a function, leading to `no such file or directory: colors` after a fresh install.
+- **Fix**: menu now sources the colors file when `command -v colors` returns a path, otherwise it invokes the already-loaded `colors` function.
+- **Next**: Re-test `menu` in a fresh terminal after install.
+
 ## Testing Strategy
 
 For each phase, we will:

--- a/spells/cantrips/menu
+++ b/spells/cantrips/menu
@@ -62,8 +62,13 @@ if [ -r "$script_dir/colors" ]; then
         # shellcheck disable=SC1090
         . "$script_dir/colors"
 elif has colors; then
-        # shellcheck disable=SC1091
-        . colors
+        colors_path=$(command -v colors 2>/dev/null || printf '')
+        if [ -n "$colors_path" ] && [ -f "$colors_path" ]; then
+                # shellcheck disable=SC1090
+                . "$colors_path"
+        else
+                colors
+        fi
 else
         RESET=''
         CYAN=''


### PR DESCRIPTION
### Motivation

- The `menu` spell failed in fresh shells when `colors` was already loaded as a function because it attempted to source a non-existent `colors` file. 
- The initialization approach preloads a minimal set (menu + imps) and relies on hotloading, so `menu` must work whether `colors` is a sourced file or a preloaded function. 

### Description

- Update `spells/cantrips/menu` so it uses `command -v colors` and sources the returned path when present, otherwise it calls the already-loaded `colors` function. 
- Add an entry to `.github/SPIRAL_DEBUG.md` documenting the fix and the root cause. 

### Testing

- No automated tests were executed for this change. 
- The change was validated by static inspection and by reproducing the failing message from the fresh-shell trace and addressing the root cause in the `menu` logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950fca61ba48320b36c4c6a08a087d3)