### PR TITLE
Fix menu alias override in invoke-wizardry

### DIFF
--- a/spells/.imps/sys/invoke-wizardry
+++ b/spells/.imps/sys/invoke-wizardry
@@ -218,6 +218,17 @@ function brace_delta(s, n, m) {
     done
   done
 
+  # If a legacy alias points menu at word-of-binding, remove it so the function wins.
+  if alias menu >/dev/null 2>&1; then
+    _iw_menu_alias=$(alias menu 2>/dev/null || :)
+    case "$_iw_menu_alias" in
+      *word-of-binding*|*_word_of_binding*)
+        _iw_debug "Removing legacy menu alias: $_iw_menu_alias"
+        unalias menu 2>/dev/null || :
+        ;;
+    esac
+  fi
+
   if ! command -v menu >/dev/null 2>&1; then
     printf '%s\n' "invoke-wizardry: ERROR - failed to load menu spell" >&2
     return 1


### PR DESCRIPTION
### Motivation

- A legacy alias could point `menu` at the `word-of-binding` dispatcher, causing `menu` to resolve to the dispatcher and fail with "word-of-binding: command name required" instead of invoking the preloaded `menu` function.
- The initialization path preloads the `menu` spell and its imps, so any lingering alias must be removed to allow the function binding to win.

### Description

- Added an alias check/cleanup in `spells/.imps/sys/invoke-wizardry` that detects a `menu` alias referencing `word-of-binding` or `_word_of_binding` and removes it with `unalias menu`.
- The removal runs after pre-loading the essential `menu` spell and before validating `command -v menu`, ensuring the preloaded function is used.
- Debug logging is emitted via the existing `_iw_debug` helper when a legacy alias is removed.

### Testing

- Ran `bash -lc '. ./spells/.imps/sys/invoke-wizardry >/dev/null 2>&1; type menu'` and confirmed `menu` is a function.
- Ran `bash -lc '. ./spells/.imps/sys/invoke-wizardry >/dev/null 2>&1; menu --help'` and confirmed the `menu` usage printed successfully (test passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951068b8b00832089dbd87aa69222a6)