### PR TITLE
Ensure env-clear returns success for word-of-binding runs

### DIFF
--- a/spells/.imps/sys/env-clear
+++ b/spells/.imps/sys/env-clear
@@ -155,6 +155,8 @@ env_clear() {
   [ -n "$_saved_disable_sandbox" ] && export WIZARDRY_DISABLE_SANDBOX="$_saved_disable_sandbox"
   [ -n "$_saved_bwrap_warning" ] && export WIZARDRY_BWRAP_WARNING="$_saved_bwrap_warning"
   [ -n "$_saved_colors_available" ] && export WIZARDRY_COLORS_AVAILABLE="$_saved_colors_available"
+
+  return 0
 }
 
 # Self-execute when run directly (not sourced)


### PR DESCRIPTION
### Motivation

- `menu` was failing in fresh shells with `env-clear: command not found` because `word-of-binding` runs of the `env-clear` imp could surface as failures when the function did not explicitly return success.
- Preloading and hotloading logic relies on `env-clear` being callable via `word_of_binding --run` without producing a non-zero exit status.

### Description

- Added an explicit `return 0` at the end of the `env_clear()` function in `spells/.imps/sys/env-clear` to ensure it reports success when invoked via `word_of_binding --run`.
- No other behavioral changes were made; the change simply guarantees a successful exit after restoring environment variables.

### Testing

- Ran `bash -lc 'source spells/.imps/sys/invoke-wizardry >/dev/null; word_of_binding --run env-clear; echo $?;'` which returned `0` (success).
- Verified that `menu --help` prints usage text using `bash -lc 'source spells/.imps/sys/invoke-wizardry >/dev/null; menu --help | head -n 5'` which produced the expected usage output.
- Confirmed that prior `menu` invocation error `env-clear: command not found` is no longer reproduced when `env-clear` is loaded via `word_of_binding` by re-running the environment-binding tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951190e995c832086963f81ce71ca65)