### PR TITLE
Allow nested word-of-binding resolution and fix main-menu color loading

### DIFF
--- a/spells/.imps/sys/env-clear
+++ b/spells/.imps/sys/env-clear
@@ -155,6 +155,8 @@ env_clear() {
   [ -n "$_saved_disable_sandbox" ] && export WIZARDRY_DISABLE_SANDBOX="$_saved_disable_sandbox"
   [ -n "$_saved_bwrap_warning" ] && export WIZARDRY_BWRAP_WARNING="$_saved_bwrap_warning"
   [ -n "$_saved_colors_available" ] && export WIZARDRY_COLORS_AVAILABLE="$_saved_colors_available"
+
+  return 0
 }
 
 # Self-execute when run directly (not sourced)

--- a/spells/.imps/sys/invoke-wizardry
+++ b/spells/.imps/sys/invoke-wizardry
@@ -194,12 +194,13 @@ invoke_wizardry() {
   if eval '[ -n "${BASH_VERSION+x}" ]' 2>/dev/null; then
     # Bash-specific command_not_found_handle
     command_not_found_handle() {
-      # Prevent infinite recursion
-      if [ "${_WIZARDRY_IN_CNF-}" = "1" ]; then
+      # Prevent infinite recursion for the same command while allowing nested lookups.
+      if [ -n "${_WIZARDRY_IN_CNF-}" ] && [ "${_WIZARDRY_IN_CNF}" = "$1" ]; then
         printf '%s: command not found\n' "$1" >&2
         return 127
       fi
-      _WIZARDRY_IN_CNF=1
+      _iw_prev_cnf="${_WIZARDRY_IN_CNF-}"
+      _WIZARDRY_IN_CNF=$1
       
       # Try word-of-binding
       _cnf_wob="$WIZARDRY_DIR/spells/.imps/sys/word-of-binding"
@@ -212,13 +213,21 @@ invoke_wizardry() {
         fi
         if command -v word_of_binding >/dev/null 2>&1 \
           && word_of_binding --run "$@" 2>/dev/null; then
-          unset _WIZARDRY_IN_CNF
+          if [ -n "$_iw_prev_cnf" ]; then
+            _WIZARDRY_IN_CNF="$_iw_prev_cnf"
+          else
+            unset _WIZARDRY_IN_CNF
+          fi
           return 0
         fi
       fi
       
       # Command truly not found
-      unset _WIZARDRY_IN_CNF
+      if [ -n "$_iw_prev_cnf" ]; then
+        _WIZARDRY_IN_CNF="$_iw_prev_cnf"
+      else
+        unset _WIZARDRY_IN_CNF
+      fi
       printf '%s: command not found\n' "$1" >&2
       return 127
     }
@@ -226,12 +235,13 @@ invoke_wizardry() {
   elif eval '[ -n "${ZSH_VERSION+x}" ]' 2>/dev/null; then
     # Zsh-specific command_not_found_handler
     command_not_found_handler() {
-      # Prevent infinite recursion
-      if [ "${_WIZARDRY_IN_CNF-}" = "1" ]; then
+      # Prevent infinite recursion for the same command while allowing nested lookups.
+      if [ -n "${_WIZARDRY_IN_CNF-}" ] && [ "${_WIZARDRY_IN_CNF}" = "$1" ]; then
         printf '%s: command not found\n' "$1" >&2
         return 127
       fi
-      _WIZARDRY_IN_CNF=1
+      _iw_prev_cnf="${_WIZARDRY_IN_CNF-}"
+      _WIZARDRY_IN_CNF=$1
       
       # Try word-of-binding
       _cnf_wob="$WIZARDRY_DIR/spells/.imps/sys/word-of-binding"
@@ -244,13 +254,21 @@ invoke_wizardry() {
         fi
         if command -v word_of_binding >/dev/null 2>&1 \
           && word_of_binding --run "$@" 2>/dev/null; then
-          unset _WIZARDRY_IN_CNF
+          if [ -n "$_iw_prev_cnf" ]; then
+            _WIZARDRY_IN_CNF="$_iw_prev_cnf"
+          else
+            unset _WIZARDRY_IN_CNF
+          fi
           return 0
         fi
       fi
       
       # Command truly not found
-      unset _WIZARDRY_IN_CNF
+      if [ -n "$_iw_prev_cnf" ]; then
+        _WIZARDRY_IN_CNF="$_iw_prev_cnf"
+      else
+        unset _WIZARDRY_IN_CNF
+      fi
       printf '%s: command not found\n' "$1" >&2
       return 127
     }

--- a/spells/menu/main-menu
+++ b/spells/menu/main-menu
@@ -26,9 +26,17 @@ esac
 set -eu
 env-clear
 
-# Load color palette (colors handles terminal capability detection internally)
-# shellcheck source=/dev/null
-. "$(command -v colors)"
+# Load color palette (colors handles terminal capability detection internally).
+# When colors is preloaded as a function, call it directly; otherwise source the file.
+if has colors; then
+  colors_path=$(command -v colors 2>/dev/null || printf '')
+  if [ -n "$colors_path" ] && [ -f "$colors_path" ]; then
+    # shellcheck disable=SC1090
+    . "$colors_path"
+  else
+    colors
+  fi
+fi
 
 if ! require menu "The main menu needs the 'menu' command to present options."; then
   return 1


### PR DESCRIPTION
### Motivation
- Command-not-found handlers could prematurely mark nested lookups as recursion and abort resolution, causing hotloading of spells/imps to fail.
- The main menu attempted to source `colors` unconditionally which fails when `colors` is preloaded as a function instead of a file.
- `env-clear` must reliably report success when invoked via `word_of_binding --run` to avoid spurious failures in preloading paths.

### Description
- Updated bash/zsh `command_not_found_handle`/`command_not_found_handler` to track recursion by command name and restore a previous recursion state via `_iw_prev_cnf`, allowing nested lookups to succeed.
- Restored prior `_WIZARDRY_IN_CNF` state after successful or failed resolution instead of unconditionally unsetting it to avoid breaking outer lookups.
- Changed `menu/main-menu` to load the color palette by preferring a preloaded `colors` function and falling back to sourcing the `colors` file when available, avoiding `. colors` failures.
- Ensured `env-clear` returns success explicitly with `return 0` after restoring environment variables.

### Testing
- Sourced `spells/.imps/sys/invoke-wizardry` and ran `word_of_binding --run temp-file menu-items`, which produced a temporary file path (success).
- Sourced `spells/.imps/sys/invoke-wizardry` and ran `await-keypress --help`, which exited with `0` (success).
- Verified repository changes were staged and committed successfully in the worktree (git commit completed).
- Full interactive end-to-end verification was not executed due to lack of a reliable interactive terminal in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951190e995c832086963f81ce71ca65)