### PR TITLE
Prefer preloaded temp_file/cleanup_file helpers in `menu` and `await-keypress`

### DIFF
--- a/spells/cantrips/await-keypress
+++ b/spells/cantrips/await-keypress
@@ -27,6 +27,15 @@ require-wizardry || return 1
 set -eu
 env-clear
 
+# Prefer preloaded imp functions (underscore form) when available.
+await_keypress_temp_file() {
+    if command -v temp_file >/dev/null 2>&1; then
+        temp_file "$@"
+    else
+        temp-file "$@"
+    fi
+}
+
 # Resolve require-command location
 if [ -n "${REQUIRE_COMMAND-}" ]; then
     require_cmd=$REQUIRE_COMMAND
@@ -56,7 +65,7 @@ if [ "${AWAIT_KEYPRESS_BUFFER_FILE+set}" = "set" ]; then
     buffer_file=$AWAIT_KEYPRESS_BUFFER_FILE
 else
     buffer_key=$(printf '%s' "$tty_device" | tr -c '[:alnum:]' '_')
-    buffer_file=$(temp-file await-keypress-buffer-"$buffer_key") || return 1
+    buffer_file=$(await_keypress_temp_file await-keypress-buffer-"$buffer_key") || return 1
 fi
 
 # Helper to restore terminal and close file descriptor

--- a/spells/cantrips/menu
+++ b/spells/cantrips/menu
@@ -32,6 +32,23 @@ env-clear
 
 script_dir=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
 
+# Prefer preloaded imp functions (underscore form) when available.
+menu_temp_file() {
+        if command -v temp_file >/dev/null 2>&1; then
+                temp_file "$@"
+        else
+                temp-file "$@"
+        fi
+}
+
+menu_cleanup_file() {
+        if command -v cleanup_file >/dev/null 2>&1; then
+                cleanup_file "$@"
+        else
+                cleanup-file "$@"
+        fi
+}
+
 # Verify that all helper spells are ready before drawing the menu.
 # Uses the shared 'require' imp for dependency checking.
 require fathom-cursor "The menu spell needs 'fathom-cursor' to place the menu." || return 1
@@ -122,8 +139,8 @@ fi
 description=$1
 shift
 
-items_file=$(temp-file menu-items) || return 1
-commands_file=$(temp-file menu-commands) || return 1
+items_file=$(menu_temp_file menu-items) || return 1
+commands_file=$(menu_temp_file menu-commands) || return 1
 cleanup_called=0
 cleanup() {
         if [ "$cleanup_called" -eq 1 ]; then
@@ -135,8 +152,8 @@ cleanup() {
                 stty "$menu_saved_tty_state" <"$menu_tty" >/dev/null 2>&1 || :
         fi
         cursor-blink on 2>/dev/null || :
-        cleanup-file "$items_file"
-        cleanup-file "$commands_file"
+        menu_cleanup_file "$items_file"
+        menu_cleanup_file "$commands_file"
 }
 trap 'cleanup; exit 1' INT TERM
 trap 'cleanup' EXIT


### PR DESCRIPTION
### Motivation

- The `menu` spell was creating temp files via external `temp-file`/`cleanup-file` commands which can fail when preloaded imp functions with underscore names exist or when PATH/word-of-binding ordering causes the external commands to be unavailable.
- The spiral debug work standardized imp true-names to underscored function names (e.g. `temp_file`/`cleanup_file`), so `menu` and its helpers should prefer bound functions when present to avoid spurious "no such file or directory" errors.
- Using preloaded functions avoids extra process forks and ensures behavior is consistent whether the imp is preloaded or hotloaded.
- This change aims to make `menu` more robust in minimal preloading and fresh-shell scenarios tracked by the spiral debug process.

### Description

- Added `menu_temp_file` and `menu_cleanup_file` wrapper helpers to `spells/cantrips/menu` that prefer `temp_file`/`cleanup_file` (underscore form) when available and fall back to `temp-file`/`cleanup-file` otherwise.
- Replaced direct calls to `temp-file` and `cleanup-file` in `menu` with `menu_temp_file` and `menu_cleanup_file` respectively.
- Added `await_keypress_temp_file` helper to `spells/cantrips/await-keypress` and replaced its `temp-file` usage with the new helper to match the same preferring behavior.
- Committed the changes with the message `Prefer preloaded temp-file helpers in menu`.

### Testing

- No automated tests were executed for this patch.
- Basic repository commands used during the edit (e.g. `git status` and commit) completed successfully.
- CI/automated test runs should be triggered by the repository pipeline to validate behavior in various shells and fresh install scenarios.
- Manual TTY-dependent menu execution was not run in this automated edit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69511e5a0c9c8320ac281517b03ae4a6)