### PR TITLE
Harden menu width handling and preload require-command

### DIFF
--- a/spells/.imps/sys/invoke-wizardry
+++ b/spells/.imps/sys/invoke-wizardry
@@ -133,6 +133,7 @@ invoke_wizardry() {
     move-cursor \
     fathom-cursor \
     fathom-terminal \
+    require-command \
     cursor-blink \
     colors; do
     # Search for spell in all categories

--- a/spells/cantrips/menu
+++ b/spells/cantrips/menu
@@ -410,6 +410,11 @@ do
         fi
 
         current_window_width=$(fathom-terminal --width)
+        case "$current_window_width" in
+                ''|*[!0-9]*)
+                        current_window_width=0
+                        ;;
+        esac
         current_max_command_length=$((current_window_width - max_name_length - 3))
         if [ "$current_max_command_length" -lt 0 ]; then
                 current_max_command_length=0


### PR DESCRIPTION
### Motivation

- Prevent the `menu` spell from failing with arithmetic errors when `fathom-terminal` returns empty or non-numeric output. 
- Ensure all helper utilities `menu` relies on can be preloaded during initialization so `menu` is available immediately after startup.

### Description

- Add a guard in `menu` to validate `fathom-terminal --width` output and coerce empty/non-numeric values to `0` before performing arithmetic. 
- Preload `require-command` in `invoke-wizardry` alongside other essential preloaded spells so dependency checks used by `menu` succeed during startup. 
- Changes applied to `spells/cantrips/menu` and `spells/.imps/sys/invoke-wizardry` to implement the above fixes. 

### Testing

- No automated tests were run for this change. 
- The change was committed locally (`git commit` succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951203c4ccc83208a268cd24b09540e)