### PR TITLE
Guard menu width, preload `require-command`, and support hyphenated spell names

### DIFF
--- a/spells/.imps/sys/invoke-wizardry
+++ b/spells/.imps/sys/invoke-wizardry
@@ -133,6 +133,7 @@ invoke_wizardry() {
     move-cursor \
     fathom-cursor \
     fathom-terminal \
+    require-command \
     cursor-blink \
     colors; do
     # Search for spell in all categories

--- a/spells/cantrips/menu
+++ b/spells/cantrips/menu
@@ -410,6 +410,11 @@ do
         fi
 
         current_window_width=$(fathom-terminal --width)
+        case "$current_window_width" in
+                ''|*[!0-9]*)
+                        current_window_width=0
+                        ;;
+        esac
         current_max_command_length=$((current_window_width - max_name_length - 3))
         if [ "$current_max_command_length" -lt 0 ]; then
                 current_max_command_length=0

--- a/spells/cantrips/require-command
+++ b/spells/cantrips/require-command
@@ -38,6 +38,14 @@ auto_install=${REQUIRE_COMMAND_ASSUME_YES:-0}
 if command -v "$command_name" >/dev/null 2>&1; then
     return 0
 fi
+case "$command_name" in
+    *-*)
+        command_alt=$(printf '%s' "$command_name" | tr '-' '_')
+        if command -v "$command_alt" >/dev/null 2>&1; then
+            return 0
+        fi
+        ;;
+esac
 
 script_dir=$(CDPATH= cd -- "$(dirname "$0")" && pwd -P)
 


### PR DESCRIPTION
### Motivation
- Prevent `menu` from failing with arithmetic errors when `fathom-terminal --width` returns empty or non-numeric output.
- Ensure `require-command` is available during initialization so spells that rely on it can validate dependencies at startup.
- Avoid false missing-dependency errors when spells are preloaded as shell functions that use underscores instead of hyphens.

### Description
- Coerce empty or non-numeric `fathom-terminal --width` output to `0` in `spells/cantrips/menu` before performing arithmetic.
- Add `require-command` to the preloaded spells list in `spells/.imps/sys/invoke-wizardry` so it is loaded during initialization.
- Update `spells/cantrips/require-command` to check a hyphen-to-underscore alternative (e.g., `fathom-cursor` → `fathom_cursor`) and succeed if that function/binary is present.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951203c4ccc83208a268cd24b09540e)