### PR TITLE
Stabilize menu cursor anchoring, coerce terminal width, and preload `require-command`

### DIFF
--- a/spells/.imps/sys/invoke-wizardry
+++ b/spells/.imps/sys/invoke-wizardry
@@ -133,6 +133,7 @@ invoke_wizardry() {
     move-cursor \
     fathom-cursor \
     fathom-terminal \
+    require-command \
     cursor-blink \
     colors; do
     # Search for spell in all categories

--- a/spells/cantrips/menu
+++ b/spells/cantrips/menu
@@ -209,6 +209,8 @@ case $start_selection in
 esac
 menu_column=1
 menu_row=1
+menu_use_saved_cursor=0
+menu_anchor_saved=0
 previous_selected=0
 window_width=0
 max_command_length=0
@@ -249,7 +251,7 @@ render_row() {
                 done
 
                 target_row=$((menu_row + row_index - 1))
-                if move-cursor "$menu_column" "$target_row"; then
+                if menu_move_cursor "$menu_column" "$target_row"; then
                         printf '\033[K'
                         printf '%b  %s%s%b' "$THEME_DIVIDER" "$pad" "$line" "$RESET"
                         printf '\r'
@@ -272,7 +274,7 @@ render_row() {
         adjusted_width=$((max_name_length + ansi_extra))
 
         target_row=$((menu_row + row_index - 1))
-        if move-cursor "$menu_column" "$target_row"; then
+        if menu_move_cursor "$menu_column" "$target_row"; then
                 printf '\033[K'
                 if [ "$highlight" -eq 1 ]; then
                         if [ "$max_command_length" -gt 0 ]; then
@@ -305,13 +307,29 @@ render_row() {
         fi
 }
 
+menu_move_cursor() {
+        x=$1
+        y=$2
+        if [ "$menu_use_saved_cursor" -eq 1 ]; then
+                printf '\033[u'
+                if [ "$y" -gt 1 ]; then
+                        printf '\033[%sB' "$((y - 1))"
+                fi
+                if [ "$x" -gt 0 ]; then
+                        printf '\033[%sG' "$x"
+                fi
+                return 0
+        fi
+        move-cursor "$x" "$y"
+}
+
 position_cursor_below_menu() {
         below_row=$((menu_row + menu_length))
         if [ "$terminal_height" -gt 0 ] && [ "$below_row" -gt "$terminal_height" ]; then
                 below_row=$terminal_height
         fi
 
-        if ! move-cursor "$menu_column" "$below_row"; then
+        if ! menu_move_cursor "$menu_column" "$below_row"; then
                 printf '\n'
         fi
 }
@@ -323,15 +341,26 @@ if [ -n "$description" ]; then
         printf '%b%s%b\n' "$THEME_HEADING" "$description" "$RESET"
 fi
 
-menu_row=$(fathom-cursor -y)
-case "$menu_row" in
-        ''|*[!0-9]*)
-                menu_row=1
-                ;;
-        0)
-                menu_row=1
-                ;;
-esac
+if menu_row=$(fathom-cursor -y 2>/dev/null); then
+        case "$menu_row" in
+                ''|*[!0-9]*)
+                        menu_row=1
+                        menu_use_saved_cursor=1
+                        ;;
+                0)
+                        menu_row=1
+                        menu_use_saved_cursor=1
+                        ;;
+        esac
+else
+        menu_row=1
+        menu_use_saved_cursor=1
+fi
+
+if [ "$menu_use_saved_cursor" -eq 1 ] && [ "$menu_anchor_saved" -eq 0 ]; then
+        printf '\033[s'
+        menu_anchor_saved=1
+fi
 
 # At this stage the cursor sits on the row immediately following the menu
 # heading (or at the top of the screen when no heading was provided). That row
@@ -410,6 +439,11 @@ do
         fi
 
         current_window_width=$(fathom-terminal --width)
+        case "$current_window_width" in
+                ''|*[!0-9]*)
+                        current_window_width=0
+                        ;;
+        esac
         current_max_command_length=$((current_window_width - max_name_length - 3))
         if [ "$current_max_command_length" -lt 0 ]; then
                 current_max_command_length=0
@@ -425,7 +459,7 @@ do
                 last_window_width=$current_window_width
                 last_max_command_length=$current_max_command_length
 
-                if move-cursor "$menu_column" "$menu_row"; then
+                if menu_move_cursor "$menu_column" "$menu_row"; then
                         printf '\033[J'
                 fi
 

--- a/spells/cantrips/require-command
+++ b/spells/cantrips/require-command
@@ -38,6 +38,14 @@ auto_install=${REQUIRE_COMMAND_ASSUME_YES:-0}
 if command -v "$command_name" >/dev/null 2>&1; then
     return 0
 fi
+case "$command_name" in
+    *-*)
+        command_alt=$(printf '%s' "$command_name" | tr '-' '_')
+        if command -v "$command_alt" >/dev/null 2>&1; then
+            return 0
+        fi
+        ;;
+esac
 
 script_dir=$(CDPATH= cd -- "$(dirname "$0")" && pwd -P)
 


### PR DESCRIPTION
### Motivation
- Prevent the menu heading from being overwritten when device-status-report (DSR) via `fathom-cursor` cannot report the current row.
- Avoid arithmetic failures when `fathom-terminal --width` returns empty or non-numeric output.
- Ensure `require-command` is available during initialization so spells can validate dependencies at startup. 
- Avoid false missing-dependency errors when a command is available under an underscore name (e.g. `fathom_cursor`).

### Description
- Add a `menu_move_cursor` helper that either delegates to `move-cursor` or uses a saved-cursor fallback (emit `\033[s`/`\033[u` and relative moves) when `fathom-cursor` fails, and route all menu positioning through it. 
- When `fathom-cursor -y` fails or returns non-numeric/zero output the menu now sets `menu_use_saved_cursor=1` and saves an anchor with `\033[s` so redraws don't clear the heading. 
- Coerce `fathom-terminal --width` output to `0` when empty or non-numeric before calculating `current_max_command_length` to avoid arithmetic errors. 
- Preload `require-command` in `spells/.imps/sys/invoke-wizardry` and update `spells/cantrips/require-command` to also check a hyphen-to-underscore alternative name using `tr '-' '_'`.

### Testing
- No automated tests were run for this change.
- The menu code was exercised locally to confirm the saved-cursor fallback prevents the heading from being wiped when `fathom-cursor` fails (manual verification).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951203c4ccc83208a268cd24b09540e)