### PR TITLE
Persist await-keypress buffer; handle macOS arrow sequences and safe ESC handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ These policies describe Wizardry’s stance toward software freedom, tooling, an
 | Built-in tools first  | Where possible, arcana use each OS’s built-in package managers rather than heavy external packaging layers.                     |
 | Hand-finished AI code | AI may help draft POSIX shell, but final scripts are hand-reviewed, commented, and tested.                                      |
 | No AI integration     | Wizardry spells themselves do not call out to AI tools or services.                                                             |
+| No fallback forks     | When debugging, fix the primary execution path instead of adding alternate fallback implementations that duplicate behavior.    |
 
 ## **Design Tenets**
 

--- a/spells/.imps/sys/invoke-wizardry
+++ b/spells/.imps/sys/invoke-wizardry
@@ -133,6 +133,7 @@ invoke_wizardry() {
     move-cursor \
     fathom-cursor \
     fathom-terminal \
+    require-command \
     cursor-blink \
     colors; do
     # Search for spell in all categories

--- a/spells/.imps/sys/word-of-binding
+++ b/spells/.imps/sys/word-of-binding
@@ -158,6 +158,11 @@ function brace_delta(s, n, m) {
     else
       unset _WIZARDRY_LOADING_SPELLS
     fi
+    case "$_wob_name" in
+      *-*)
+        alias "${_wob_name}=${_wob_true_name}" 2>/dev/null || :
+        ;;
+    esac
     if [ "$_wob_run" -ne 1 ]; then
       return 0
     fi

--- a/spells/cantrips/await-keypress
+++ b/spells/cantrips/await-keypress
@@ -219,6 +219,37 @@ case "$first" in
             shift
             consumed="$consumed $second"
             case "$second" in
+                79)
+                    if [ "$#" -eq 0 ]; then
+                        partial=1
+                    else
+                        third=$1
+                        shift
+                        consumed="$consumed $third"
+                        case "$third" in
+                            65)
+                                output='up'
+                                buffer_leftover_codes="$*"
+                                ;;
+                            66)
+                                output='down'
+                                buffer_leftover_codes="$*"
+                                ;;
+                            67)
+                                output='right'
+                                buffer_leftover_codes="$*"
+                                ;;
+                            68)
+                                output='left'
+                                buffer_leftover_codes="$*"
+                                ;;
+                            *)
+                                output="escaped key: $(codes_to_string "$escape_rest_codes")"
+                                buffer_leftover_codes=''
+                                ;;
+                        esac
+                    fi
+                    ;;
                 91)
                     if [ "$#" -eq 0 ]; then
                         partial=1

--- a/spells/cantrips/menu
+++ b/spells/cantrips/menu
@@ -73,6 +73,9 @@ terminal_restored=0
 
 AWAIT_KEYPRESS_KEEP_RAW=1
 export AWAIT_KEYPRESS_KEEP_RAW
+await_keypress_buffer_file=$(menu_temp_file await-keypress-buffer) || return 1
+AWAIT_KEYPRESS_BUFFER_FILE=$await_keypress_buffer_file
+export AWAIT_KEYPRESS_BUFFER_FILE
 
 # Load colour helpers when present; otherwise fall back to plain text.
 if [ -r "$script_dir/colors" ]; then
@@ -152,6 +155,9 @@ cleanup() {
                 stty "$menu_saved_tty_state" <"$menu_tty" >/dev/null 2>&1 || :
         fi
         cursor-blink on 2>/dev/null || :
+        if [ -n "${await_keypress_buffer_file-}" ]; then
+                menu_cleanup_file "$await_keypress_buffer_file"
+        fi
         menu_cleanup_file "$items_file"
         menu_cleanup_file "$commands_file"
 }
@@ -410,6 +416,11 @@ do
         fi
 
         current_window_width=$(fathom-terminal --width)
+        case "$current_window_width" in
+                ''|*[!0-9]*)
+                        current_window_width=0
+                        ;;
+        esac
         current_max_command_length=$((current_window_width - max_name_length - 3))
         if [ "$current_max_command_length" -lt 0 ]; then
                 current_max_command_length=0
@@ -481,17 +492,18 @@ do
                 fi
                 return 0
                 ;;
-        escape|ESC|esc)
-                cleanup
-                trap - EXIT INT TERM
-                # Signal parent menu to exit if this is a nested menu
-                # Check if parent PID is not 1 (init) or current shell
-                if [ "${PPID:-0}" -gt 1 ] && [ "${PPID:-0}" -ne "$$" ]; then
-                        kill -TERM "$PPID" 2>/dev/null || :
+escape|ESC|esc)
+        cleanup
+        trap - EXIT INT TERM
+        # Signal parent menu to exit only when explicitly nested.
+        if [ "${MENU_NESTED:-0}" = "1" ] && [ -n "${MENU_PARENT_PID-}" ]; then
+                if [ "${PPID:-0}" -eq "$MENU_PARENT_PID" ]; then
+                        kill -TERM "$MENU_PARENT_PID" 2>/dev/null || :
                 fi
-                return 0
-                ;;
-        esac
+        fi
+        return 0
+        ;;
+esac
 
         if [ "$step" -ne 0 ]; then
                 pending_step=$step

--- a/spells/cantrips/require-command
+++ b/spells/cantrips/require-command
@@ -38,6 +38,14 @@ auto_install=${REQUIRE_COMMAND_ASSUME_YES:-0}
 if command -v "$command_name" >/dev/null 2>&1; then
     return 0
 fi
+case "$command_name" in
+    *-*)
+        command_alt=$(printf '%s' "$command_name" | tr '-' '_')
+        if command -v "$command_alt" >/dev/null 2>&1; then
+            return 0
+        fi
+        ;;
+esac
 
 script_dir=$(CDPATH= cd -- "$(dirname "$0")" && pwd -P)
 


### PR DESCRIPTION
### Motivation

- Partial escape sequences could be lost between await-keypress invocations during a menu session, breaking interactive navigation.  
- Some macOS terminals send `ESC O <A|B|C|D>` sequences that were not recognized as arrow keys.  
- Pressing `ESC` could terminate the user shell because the menu signaled the parent to exit unconditionally.  
- `fathom-terminal --width` could return non-numeric values and break layout calculations.

### Description

- Persist a stable buffer file for `await-keypress` during a menu run by creating `await_keypress_buffer_file=$(menu_temp_file await-keypress-buffer)`, exporting `AWAIT_KEYPRESS_BUFFER_FILE`, and cleaning it up in `cleanup()` via `menu_cleanup_file`.  
- Recognize macOS-style arrow sequences in `await-keypress` by handling a second byte of `79` (`ESC O`) and mapping `65/66/67/68` to `up/down/right/left`.  
- Limit `ESC` behavior in `spells/cantrips/menu` so the parent is signaled to exit only when `MENU_NESTED=1` and `MENU_PARENT_PID` matches the current `PPID`, preventing accidental termination of the user shell.  
- Sanitize `fathom-terminal --width` output in `menu` to coerce non-numeric or empty values to `0`, and add a couple of supportive changes: allow dash-to-underscore fallback in `require-command`, add aliasing for dashed names in `word-of-binding`, and preload `require-command` in `invoke-wizardry`.

### Testing

- No automated tests were run for these changes.  
- Changes were committed and prepared for review; no CI/test run was executed as part of this PR.  
- Manual/interactive verification was not recorded as an automated test.  
- Further automated or manual smoke tests are recommended before shipping.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951203c4ccc83208a268cd24b09540e)