### PR TITLE
Fix await-keypress buffering for escape sequences

### DIFF
--- a/spells/cantrips/await-keypress
+++ b/spells/cantrips/await-keypress
@@ -125,6 +125,7 @@ fi
 
 codes=''
 had_buffer=0
+read_extra=0
 if [ -n "$buffer_codes" ]; then
     had_buffer=1
     codes=$buffer_codes
@@ -139,8 +140,27 @@ else
     codes=$first_codes
 fi
 
+if [ "$skip_stty" -eq 0 ]; then
+    if [ "$had_buffer" -eq 0 ]; then
+        read_extra=1
+    else
+        set -- $codes
+        if [ "$#" -gt 0 ] && [ "$1" -eq 27 ]; then
+            if [ "$#" -eq 1 ]; then
+                read_extra=1
+            elif [ "$2" -eq 91 ] || [ "$2" -eq 79 ]; then
+                if [ "$#" -eq 2 ]; then
+                    read_extra=1
+                elif [ "$2" -eq 91 ] && [ "$3" -eq 51 ] && [ "$#" -eq 3 ]; then
+                    read_extra=1
+                fi
+            fi
+        fi
+    fi
+fi
+
 # Allow escape sequences to provide additional bytes.
-if [ "$skip_stty" -eq 0 ] && [ "$had_buffer" -eq 0 ]; then
+if [ "$read_extra" -eq 1 ]; then
     if ! stty -icanon -echo min 0 time 1 <&3 2>/dev/null; then
         warn 'await-keypress: unable to update terminal timing'
         return 1
@@ -148,7 +168,7 @@ if [ "$skip_stty" -eq 0 ] && [ "$had_buffer" -eq 0 ]; then
 fi
 
 # Read any additional bytes from escape sequences
-if [ "$had_buffer" -eq 0 ]; then
+if [ "$read_extra" -eq 1 ]; then
     while :; do
         extra=$(dd bs=1 count=1 2>/dev/null <&3 | od -An -t u1 -v | tr -s '[:space:]' ' ')
         extra=${extra# }


### PR DESCRIPTION
### Motivation
- Arrow keys produced no navigation because `await-keypress` could receive partial escape-sequence bytes from its buffer and then stop without reading the rest. 
- The menu relied on `await-keypress` to emit normalized keys like `up`/`down`/`enter`, so fixing its buffering is required to restore interactive navigation. 
- The logic should only adjust terminal timing (`stty min time`) when additional bytes are expected so responsiveness and terminal state are preserved. 
- Keep the change minimal and focused on handling buffered/partial escape sequences so preloading/hotloading changes to spells/imps remain compatible.

### Description
- Added `read_extra` detection that inspects buffered codes and sets a flag when the data begins with an escape (27) and appears to be an incomplete escape sequence. 
- Only swap `stty` into the short-timeout mode (`min 0 time 1`) when `read_extra` indicates more bytes should be read, avoiding unnecessary timing changes. 
- Made the additional-byte read loop conditional on `read_extra` instead of always running when no buffer was present. 
- Kept existing behavior for unbuffered reads and for restoring the terminal state via the existing `restore_terminal`/traps.

### Testing
- No automated tests were run because this behavior requires an interactive TTY to exercise escape-sequence input. 
- The change was committed (`git commit` succeeded) and is ready for interactive verification in a real terminal to confirm arrow-key and Enter behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69512b9ea414832097600e9102e61229)