### PR TITLE
Fix imp status output formatting in validate-spells

### DIFF
--- a/spells/system/validate-spells
+++ b/spells/system/validate-spells
@@ -174,8 +174,8 @@ for spell_info in "$@"; do
       if [ "$validate_imps" -eq 1 ] && [ "$show_status" -eq 1 ]; then
         category=$(printf '%s' "$spell" | cut -d/ -f1)
         imp_name=$(printf '%s' "$spell" | sed 's|.*/||')
-        # Format: category:status:name (status: L=loaded, A=available)
-        imp_results="${imp_results}${imp_results:+ }${category}:L:${imp_name}"
+        # Format: category|status|name (status: L=loaded, A=available)
+        imp_results="${imp_results}${imp_results:+ }${category}|L|${imp_name}"
       elif [ "$quiet" -eq 0 ] && [ "$show_status" -eq 1 ]; then
         # For spells, show individually
         printf '\033[32m✓\033[0m Loaded spell: %s\n' "$spell"
@@ -187,8 +187,8 @@ for spell_info in "$@"; do
       if [ "$validate_imps" -eq 1 ] && [ "$show_status" -eq 1 ]; then
         category=$(printf '%s' "$spell" | cut -d/ -f1)
         imp_name=$(printf '%s' "$spell" | sed 's|.*/||')
-        # Format: category:status:name (status: L=loaded, A=available)
-        imp_results="${imp_results}${imp_results:+ }${category}:A:${imp_name}"
+        # Format: category|status|name (status: L=loaded, A=available)
+        imp_results="${imp_results}${imp_results:+ }${category}|A|${imp_name}"
       elif [ "$quiet" -eq 0 ] && [ "$show_status" -eq 1 ]; then
         # For spells, show individually
         printf '\033[34m●\033[0m Available spell: %s\n' "$spell"
@@ -213,7 +213,7 @@ if [ "$validate_imps" -eq 1 ] && [ "$quiet" -eq 0 ] && [ "$show_status" -eq 1 ];
   # Get all unique categories
   categories=""
   for result in $imp_results; do
-    category=$(printf '%s' "$result" | cut -d: -f1)
+    category=$(printf '%s' "$result" | cut -d'|' -f1)
     # Add category to list if not already present
     case " $categories " in
       *" $category "*) ;;
@@ -228,9 +228,9 @@ if [ "$validate_imps" -eq 1 ] && [ "$quiet" -eq 0 ] && [ "$show_status" -eq 1 ];
     
     # Collect imps for this category
     for result in $imp_results; do
-      result_category=$(printf '%s' "$result" | cut -d: -f1)
-      result_status=$(printf '%s' "$result" | cut -d: -f2)
-      result_name=$(printf '%s' "$result" | cut -d: -f3-)
+      result_category=$(printf '%s' "$result" | cut -d'|' -f1)
+      result_status=$(printf '%s' "$result" | cut -d'|' -f2)
+      result_name=$(printf '%s' "$result" | cut -d'|' -f3-)
       
       if [ "$result_category" = "$category" ]; then
         if [ "$result_status" = "L" ]; then


### PR DESCRIPTION
### Motivation
- The imp status output was leaking category/status tokens into the printed lists, producing cluttered lines when grouping imps. 
- The goal is to preserve grouped output (loaded vs available per category) while preventing the delimiter from colliding with imp names. 

### Description
- Change the internal `imp_results` encoding from `category:status:name` to `category|status|name` to avoid ambiguous `:` tokens. 
- Update all parsing sites to split on `|` instead of `:` using `cut -d'|'` and update related comments. 
- The change is localized to `spells/system/validate-spells` and keeps the grouped category output logic intact. 

### Testing
- No automated tests were run for this change. 
- The change was committed to the `work` branch (`git commit` succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952a56b75d88320ac3fb3b6a4bea6f5)