### PR TITLE
Require external validate-spells for banish and group spell/imp status output

### DIFF
--- a/spells/system/banish
+++ b/spells/system/banish
@@ -303,16 +303,12 @@ banish_process_level() {
       fi
       printf '  %s✓%s Wizardry structure: Spells directory exists\n' "$_green" "$_reset"
       
-      # Determine how to call validate_spells (function or command)
-      _validate_cmd="validate_spells"
-      if ! command -v validate_spells >/dev/null 2>&1; then
-        # Not available as function, try as external command
-        if [ -x "${WIZARDRY_DIR}/spells/system/validate-spells" ]; then
-          _validate_cmd="${WIZARDRY_DIR}/spells/system/validate-spells"
-        else
-          printf '  %s✗%s Cannot find validate-spells (needed for validation)\n' "$_red" "$_reset"
-          return 1
-        fi
+      # Use external validate-spells script (banish relies on command output capture)
+      if [ -x "${WIZARDRY_DIR}/spells/system/validate-spells" ]; then
+        _validate_cmd_capture="${WIZARDRY_DIR}/spells/system/validate-spells"
+      else
+        printf '  %s✗%s Cannot find validate-spells (needed for validation)\n' "$_red" "$_reset"
+        return 1
       fi
       
       # Validate spells (show detailed status)
@@ -320,7 +316,7 @@ banish_process_level() {
       if [ -n "$spell_list" ]; then
         # Check for any missing spells first
         # Use eval for variable function calls in command substitution (see CODE_POLICY_FUNCTION_CALLS.md)
-        missing=$(eval "$_validate_cmd --missing-only $spell_list" 2>/dev/null || true)
+        missing=$(eval "$_validate_cmd_capture --missing-only $spell_list" 2>/dev/null || true)
         if [ -n "$missing" ]; then
           printf '  %s✗%s Required spells: Missing: %s\n' "$_red" "$_reset" "$missing"
           return 1
@@ -328,7 +324,7 @@ banish_process_level() {
         
         # Show detailed status (loaded vs available)
         printf '  Required spells:\n'
-        spell_output=$(eval "$_validate_cmd --show-status $spell_list" 2>&1) || true
+        spell_output=$(eval "$_validate_cmd_capture --show-status $spell_list" 2>&1) || true
         if [ -n "$spell_output" ]; then
           printf '%s\n' "$spell_output" | sed 's/^/    /'
         else
@@ -341,7 +337,7 @@ banish_process_level() {
       if [ -n "$imp_list" ]; then
         # Check for any missing imps first
         # Use eval for variable function calls in command substitution (see CODE_POLICY_FUNCTION_CALLS.md)
-        missing=$(eval "$_validate_cmd --imps --missing-only $imp_list" 2>/dev/null || true)
+        missing=$(eval "$_validate_cmd_capture --imps --missing-only $imp_list" 2>/dev/null || true)
         if [ -n "$missing" ]; then
           printf '  %s✗%s Required imps: Missing: %s\n' "$_red" "$_reset" "$missing"
           return 1
@@ -349,7 +345,7 @@ banish_process_level() {
         
         # Show detailed status (loaded vs available)
         printf '  Required imps:\n'
-        imp_output=$(eval "$_validate_cmd --imps --show-status $imp_list" 2>&1) || true
+        imp_output=$(eval "$_validate_cmd_capture --imps --show-status $imp_list" 2>&1) || true
         if [ -n "$imp_output" ]; then
           printf '%s\n' "$imp_output" | sed 's/^/    /'
         else

--- a/spells/system/validate-spells
+++ b/spells/system/validate-spells
@@ -120,18 +120,45 @@ available_count=0
 # Store results as newline-separated "category|status|name" entries
 imp_results=""
 
+# For spells with --show-status, collect grouped output
+spell_loaded=""
+spell_available=""
+spell_unavailable=""
+
 for spell_info in "$@"; do
-  # Parse spell:dir format
-  case "$spell_info" in
-    *:*)
-      spell=$(printf '%s' "$spell_info" | cut -d: -f1)
-      dir=$(printf '%s' "$spell_info" | cut -d: -f2)
-      ;;
-    *)
-      spell=$spell_info
-      dir=$default_dir
-      ;;
-  esac
+  status_override=""
+  # Parse spell:dir format (or category:status:name for imps)
+  if [ "$validate_imps" -eq 1 ]; then
+    case "$spell_info" in
+      *:*:*)
+        category=${spell_info%%:*}
+        rest=${spell_info#*:}
+        status=${rest%%:*}
+        name_rest=${rest#*:}
+        case "$status" in
+          L|A) status_override=$status ;;
+          *) status_override="" ;;
+        esac
+        spell="${category}/${name_rest}"
+        dir=$default_dir
+        ;;
+      *)
+        spell=$spell_info
+        dir=$default_dir
+        ;;
+    esac
+  else
+    case "$spell_info" in
+      *:*)
+        spell=$(printf '%s' "$spell_info" | cut -d: -f1)
+        dir=$(printf '%s' "$spell_info" | cut -d: -f2)
+        ;;
+      *)
+        spell=$spell_info
+        dir=$default_dir
+        ;;
+    esac
+  fi
   
   # Check if spell/imp exists
   if [ "$validate_imps" -eq 1 ]; then
@@ -152,17 +179,23 @@ for spell_info in "$@"; do
   
   # Check if loaded as function (try both hyphenated and underscored versions)
   is_loaded=0
-  for name_variant in "$func_name" "$(printf '%s' "$func_name" | tr '-' '_')"; do
-    if command -v "$name_variant" >/dev/null 2>&1; then
-      func_type=$(type "$name_variant" 2>/dev/null || true)
-      case "$func_type" in
-        *"function"*|*"shell function"*)
-          is_loaded=1
-          break
-          ;;
-      esac
+  if [ -n "$status_override" ]; then
+    if [ "$status_override" = "L" ]; then
+      is_loaded=1
     fi
-  done
+  else
+    for name_variant in "$func_name" "$(printf '%s' "$func_name" | tr '-' '_')"; do
+      if command -v "$name_variant" >/dev/null 2>&1; then
+        func_type=$(type "$name_variant" 2>/dev/null || true)
+        case "$func_type" in
+          *"function"*|*"shell function"*)
+            is_loaded=1
+            break
+            ;;
+        esac
+      fi
+    done
+  fi
   
   if [ -f "$spell_path" ]; then
     found_count=$((found_count + 1))
@@ -178,8 +211,8 @@ for spell_info in "$@"; do
         imp_results="${imp_results}${imp_results:+
 }${category}|L|${imp_name}"
       elif [ "$quiet" -eq 0 ] && [ "$show_status" -eq 1 ]; then
-        # For spells, show individually
-        printf '\033[32m✓\033[0m Loaded spell: %s\n' "$spell"
+        # For spells, collect grouped output
+        spell_loaded="${spell_loaded}${spell_loaded:+ }${spell}"
       fi
     else
       available_count=$((available_count + 1))
@@ -192,8 +225,8 @@ for spell_info in "$@"; do
         imp_results="${imp_results}${imp_results:+
 }${category}|A|${imp_name}"
       elif [ "$quiet" -eq 0 ] && [ "$show_status" -eq 1 ]; then
-        # For spells, show individually
-        printf '\033[34m●\033[0m Available spell: %s\n' "$spell"
+        # For spells, collect grouped output
+        spell_available="${spell_available}${spell_available:+ }${spell}"
       fi
     fi
     
@@ -206,8 +239,50 @@ for spell_info in "$@"; do
     fi
   else
     missing="${missing:+$missing }$spell"
+    if [ "$quiet" -eq 0 ] && [ "$show_status" -eq 1 ] && [ "$validate_imps" -eq 0 ]; then
+      spell_unavailable="${spell_unavailable}${spell_unavailable:+ }${spell}"
+    fi
   fi
 done
+
+# Output grouped results for spells with --show-status
+if [ "$validate_imps" -eq 0 ] && [ "$quiet" -eq 0 ] && [ "$show_status" -eq 1 ]; then
+  if [ -n "$spell_loaded" ]; then
+    spell_loaded_count=0
+    for spell in $spell_loaded; do
+      spell_loaded_count=$((spell_loaded_count + 1))
+    done
+    if [ "$spell_loaded_count" -eq 1 ]; then
+      printf '\033[32m✓\033[0m Loaded spell: %s\n' "$spell_loaded"
+    else
+      printf '\033[32m✓\033[0m Loaded spells: %s\n' "$spell_loaded"
+    fi
+  fi
+
+  if [ -n "$spell_available" ]; then
+    spell_available_count=0
+    for spell in $spell_available; do
+      spell_available_count=$((spell_available_count + 1))
+    done
+    if [ "$spell_available_count" -eq 1 ]; then
+      printf '\033[34m●\033[0m Available spell: %s\n' "$spell_available"
+    else
+      printf '\033[34m●\033[0m Available spells: %s\n' "$spell_available"
+    fi
+  fi
+
+  if [ -n "$spell_unavailable" ]; then
+    spell_unavailable_count=0
+    for spell in $spell_unavailable; do
+      spell_unavailable_count=$((spell_unavailable_count + 1))
+    done
+    if [ "$spell_unavailable_count" -eq 1 ]; then
+      printf '\033[31m✗\033[0m Unavailable spell: %s\n' "$spell_unavailable"
+    else
+      printf '\033[31m✗\033[0m Unavailable spells: %s\n' "$spell_unavailable"
+    fi
+  fi
+fi
 
 # Output grouped results for imps with --show-status
 if [ "$validate_imps" -eq 1 ] && [ "$quiet" -eq 0 ] && [ "$show_status" -eq 1 ]; then


### PR DESCRIPTION
### Motivation
- Ensure `banish` can reliably capture `validate-spells` output by using the external script rather than an in-shell function fallback.  
- Allow precomputed imp status hints so callers that capture output (subshells) can trust grouped imp status lines.  
- Simplify and compact spell status presentation into `loaded`, `available`, and `unavailable` groups for easier human reading.  
- Preserve the existing newline `category|status|name` `imp_results` format so downstream consumers remain compatible.  

### Description
- `banish` now requires the external `spells/system/validate-spells` script and uses it for captured `eval` calls via `_validate_cmd_capture`, removing the function fallback.  
- `validate-spells` was extended to accept `category:status:name` for imps and honor a `status_override` (`L` or `A`) so imps can be treated as loaded/available without probing the function table.  
- Collected spell statuses into grouped variables (`spell_loaded`, `spell_available`, `spell_unavailable`) and emit compact, pluralized lines when `--show-status` is used.  
- Kept `imp_results` as newline-separated `category|status|name` entries and preserved per-category grouping logic when printing imps.  

### Testing
- No automated test suite was executed as part of this change.  
- The change was staged and committed successfully (`git add`/`git commit`) with the updated `banish` and `validate-spells` files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952a827ebdc8320bb0ebf721a953482)