### PR TITLE
Populate higher-level imps, dedupe across levels, and improve banish/validate output

### DIFF
--- a/spells/.imps/sys/spell-levels
+++ b/spells/.imps/sys/spell-levels
@@ -38,6 +38,14 @@ get_level_spells() {
 get_level_imps() {
   case "$1" in
     1) printf 'sys/invoke-wizardry sys/require-wizardry sys/require sys/castable sys/env-clear sys/on-exit sys/clear-traps cond/has cond/there cond/is cond/empty cond/nonempty out/say out/warn out/die out/fail out/info out/step out/success out/debug fs/temp-file fs/temp-dir fs/cleanup-file fs/cleanup-dir input/tty-save input/tty-restore input/tty-raw input/read-line str/contains str/trim str/equals str/starts str/ends paths/here paths/parent paths/file-name paths/abs-path' ;;
+    2) printf 'menu/is-submenu menu/is-integer menu/category-title menu/exit-label' ;;
+    3) printf 'fs/xattr-helper-usable fs/xattr-list-keys fs/xattr-read-value' ;;
+    5) printf 'fs/backup menu/detect-trash text/read-file text/write-file text/lines text/each' ;;
+    6) printf 'input/select-input lex/parse lex/from lex/to' ;;
+    7) printf 'input/validate-command input/validate-name lex/and lex/or' ;;
+    9) printf 'fs/config-get fs/config-set fs/config-has fs/config-del' ;;
+    10) printf 'test/boot test/stub-cursor-blink test/stub-fathom-terminal test/stub-stty test/stub-await-keypress test/stub-fathom-cursor test/stub-move-cursor test/test-bootstrap sys/rc-add-line sys/rc-has-line sys/rc-remove-line' ;;
+    13) printf 'sys/os sys/term text/detect-indent-char text/detect-indent-width' ;;
     *) printf '' ;;
   esac
 }

--- a/spells/system/banish
+++ b/spells/system/banish
@@ -4,7 +4,7 @@
 # This spell assumption-checks, self-heals, and tests the environment,
 # ensuring all prerequisites are met for each spell level.
 
-show_usage() {
+banish_usage() {
   cat <<'USAGE'
 Usage: banish [LEVEL] [OPTIONS]
 
@@ -61,7 +61,7 @@ USAGE
 banish() {
 case "${1-}" in
 --help|--usage|-h)
-  show_usage
+  banish_usage
   return 0
   ;;
 esac
@@ -162,7 +162,7 @@ while [ "$#" -gt 0 ]; do
       ;;
     -*)
       printf 'Error: unknown option: %s\n' "$1" >&2
-      show_usage >&2
+      banish_usage >&2
       return 2
       ;;
     *)
@@ -174,7 +174,7 @@ while [ "$#" -gt 0 ]; do
           ;;
         *)
           printf 'Error: unexpected argument: %s\n' "$1" >&2
-          show_usage >&2
+          banish_usage >&2
           return 2
           ;;
       esac
@@ -185,7 +185,7 @@ done
 # Validate level
 if [ "$target_level" -lt 0 ] || [ "$target_level" -gt 27 ]; then
   printf 'Error: level must be 0-27, got: %s\n' "$target_level" >&2
-  show_usage >&2
+  banish_usage >&2
   return 2
 fi
 
@@ -212,6 +212,8 @@ _esc=$(printf '\033')
 _green="${_esc}[32m"
 _red="${_esc}[31m"
 _reset="${_esc}[0m"
+
+_banish_seen_imps=""
 
 # Run level-specific checks and actions using case statement
 banish_process_level() {
@@ -302,50 +304,62 @@ banish_process_level() {
         return 1
       fi
       printf '  %s✓%s Wizardry structure: Spells directory exists\n' "$_green" "$_reset"
-      
-      # Use external validate-spells script (banish relies on command output capture)
-      if [ -x "${WIZARDRY_DIR}/spells/system/validate-spells" ]; then
-        _validate_cmd_capture="${WIZARDRY_DIR}/spells/system/validate-spells"
-      else
-        printf '  %s✗%s Cannot find validate-spells (needed for validation)\n' "$_red" "$_reset"
+
+      # Check installer presence (single item - combine on one line)
+      if [ ! -f "${WIZARDRY_DIR}/install" ]; then
+        printf '  %s✗%s Installer: install script not found\n' "$_red" "$_reset"
         return 1
       fi
+      printf '  %s✓%s Installer: install script present\n' "$_green" "$_reset"
       
-      # Validate spells (show detailed status)
+      # Check spells
       spell_list=$(get_level_spells 1)
       if [ -n "$spell_list" ]; then
-        # Check for any missing spells first
-        # Use eval for variable function calls in command substitution (see CODE_POLICY_FUNCTION_CALLS.md)
-        missing=$(eval "$_validate_cmd_capture --missing-only $spell_list" 2>/dev/null || true)
-        if [ -n "$missing" ]; then
-          printf '  %s✗%s Required spells: Missing: %s\n' "$_red" "$_reset" "$missing"
+        if ! eval "validate_spells --quiet $spell_list" 2>/dev/null; then
+          missing=$(eval "validate_spells --missing-only $spell_list" 2>/dev/null || true)
+          case "$missing" in
+            *" "*) label="Spells" ;;
+            *) label="Spell" ;;
+          esac
+          printf '  %s✗%s %s: Missing: %s\n' "$_red" "$_reset" "$label" "$missing"
           return 1
         fi
-        
-        # Show detailed status (loaded vs available)
-        printf '  Required spells:\n'
-        spell_output=$(eval "$_validate_cmd_capture --show-status $spell_list" 2>&1) || true
+        printf '  Spells:\n'
+        spell_output=$(eval "validate_spells --show-status $spell_list" 2>&1) || true
         if [ -n "$spell_output" ]; then
           printf '%s\n' "$spell_output" | sed 's/^/    /'
         else
           printf '    %s(no spell status available)%s\n' "$_red" "$_reset"
         fi
       fi
-      
-      # Validate imps (show detailed status)
+
+      # Check imps
       imp_list=$(get_level_imps 1)
       if [ -n "$imp_list" ]; then
-        # Check for any missing imps first
-        # Use eval for variable function calls in command substitution (see CODE_POLICY_FUNCTION_CALLS.md)
-        missing=$(eval "$_validate_cmd_capture --imps --missing-only $imp_list" 2>/dev/null || true)
-        if [ -n "$missing" ]; then
-          printf '  %s✗%s Required imps: Missing: %s\n' "$_red" "$_reset" "$missing"
+        new_imp_list=""
+        for imp in $imp_list; do
+          case " ${_banish_seen_imps} " in
+            *" ${imp} "*) ;;
+            *)
+              new_imp_list="${new_imp_list}${new_imp_list:+ }${imp}"
+              _banish_seen_imps="${_banish_seen_imps}${_banish_seen_imps:+ }${imp}"
+              ;;
+          esac
+        done
+        imp_list=$new_imp_list
+      fi
+      if [ -n "$imp_list" ]; then
+        if ! eval "validate_spells --quiet --imps $imp_list" 2>/dev/null; then
+          missing=$(eval "validate_spells --imps --missing-only $imp_list" 2>/dev/null || true)
+          case "$missing" in
+            *" "*) label="Imps" ;;
+            *) label="Imp" ;;
+          esac
+          printf '  %s✗%s %s: Missing: %s\n' "$_red" "$_reset" "$label" "$missing"
           return 1
         fi
-        
-        # Show detailed status (loaded vs available)
-        printf '  Required imps:\n'
-        imp_output=$(eval "$_validate_cmd_capture --imps --show-status $imp_list" 2>&1) || true
+        printf '  Imps:\n'
+        imp_output=$(eval "validate_spells --imps --show-status $imp_list" 2>&1) || true
         if [ -n "$imp_output" ]; then
           printf '%s\n' "$imp_output" | sed 's/^/    /'
         else
@@ -356,17 +370,6 @@ banish_process_level() {
       
     2)
       # Level 2: Menu System
-      
-      # Check spells (single item - combine on one line)
-      spell_list=$(get_level_spells 2)
-      if [ -n "$spell_list" ]; then
-        if ! validate_spells --quiet $spell_list 2>/dev/null; then
-          missing=$(validate_spells --missing-only $spell_list)
-          printf '  %s✗%s Menu spells: Missing: %s\n' "$_red" "$_reset" "$missing"
-          return 1
-        fi
-        printf '  %s✓%s Menu spells: All found\n' "$_green" "$_reset"
-      fi
       
       # Check stty (single item - combine on one line)
       if ! command -v stty >/dev/null 2>&1; then
@@ -390,6 +393,69 @@ banish_process_level() {
       else
         printf '  %s✓%s Terminal control: stty available\n' "$_green" "$_reset"
       fi
+
+      # Check spells
+      spell_list=$(get_level_spells 2)
+      if [ -n "$spell_list" ]; then
+        if ! eval "validate_spells --quiet $spell_list" 2>/dev/null; then
+          missing=$(eval "validate_spells --missing-only $spell_list" 2>/dev/null || true)
+          case "$missing" in
+            *" "*) label="Spells" ;;
+            *) label="Spell" ;;
+          esac
+          printf '  %s✗%s %s: Missing: %s\n' "$_red" "$_reset" "$label" "$missing"
+          return 1
+        fi
+        printf '  Spells:\n'
+        spell_output=$(eval "validate_spells --show-status $spell_list" 2>&1) || true
+        if [ -n "$spell_output" ]; then
+          printf '%s\n' "$spell_output" | sed 's/^/    /'
+        else
+          printf '    %s(no spell status available)%s\n' "$_red" "$_reset"
+        fi
+      fi
+
+      # Check imps
+      imp_list=$(get_level_imps 2)
+      had_imps=0
+      if [ -n "$imp_list" ]; then
+        had_imps=1
+        new_imp_list=""
+        for imp in $imp_list; do
+          case " ${_banish_seen_imps} " in
+            *" ${imp} "*) ;;
+            *)
+              new_imp_list="${new_imp_list}${new_imp_list:+ }${imp}"
+              _banish_seen_imps="${_banish_seen_imps}${_banish_seen_imps:+ }${imp}"
+              ;;
+          esac
+        done
+        imp_list=$new_imp_list
+      fi
+      if [ -n "$imp_list" ]; then
+        if ! eval "validate_spells --quiet --imps $imp_list" 2>/dev/null; then
+          missing=$(eval "validate_spells --imps --missing-only $imp_list" 2>/dev/null || true)
+          case "$missing" in
+            *" "*) label="Imps" ;;
+            *) label="Imp" ;;
+          esac
+          printf '  %s✗%s %s: Missing: %s\n' "$_red" "$_reset" "$label" "$missing"
+          return 1
+        fi
+        printf '  Imps:\n'
+        imp_output=$(eval "validate_spells --imps --show-status $imp_list" 2>&1) || true
+        if [ -n "$imp_output" ]; then
+          printf '%s\n' "$imp_output" | sed 's/^/    /'
+        else
+          printf '    %s(no imp status available)%s\n' "$_red" "$_reset"
+        fi
+      elif [ "$had_imps" -eq 1 ]; then
+        printf '  Imps:\n'
+        printf '    (all listed earlier)\n'
+      else
+        printf '  Imps:\n'
+        printf '    (none)\n'
+      fi
       ;;
       
     27)
@@ -405,26 +471,67 @@ banish_process_level() {
     *)
       # Levels 3-26: Standard validation pattern
       
-      # Check spells (single item - combine on one line)
+      # Check spells
       spell_list=$(get_level_spells "$level")
       if [ -n "$spell_list" ]; then
-        if ! validate_spells --quiet $spell_list 2>/dev/null; then
-          missing=$(validate_spells --missing-only $spell_list)
-          printf '  %s✗%s Spells: Missing: %s\n' "$_red" "$_reset" "$missing"
+        if ! eval "validate_spells --quiet $spell_list" 2>/dev/null; then
+          missing=$(eval "validate_spells --missing-only $spell_list" 2>/dev/null || true)
+          case "$missing" in
+            *" "*) label="Spells" ;;
+            *) label="Spell" ;;
+          esac
+          printf '  %s✗%s %s: Missing: %s\n' "$_red" "$_reset" "$label" "$missing"
           return 1
         fi
-        printf '  %s✓%s Spells: All found\n' "$_green" "$_reset"
+        printf '  Spells:\n'
+        spell_output=$(eval "validate_spells --show-status $spell_list" 2>&1) || true
+        if [ -n "$spell_output" ]; then
+          printf '%s\n' "$spell_output" | sed 's/^/    /'
+        else
+          printf '    %s(no spell status available)%s\n' "$_red" "$_reset"
+        fi
       fi
-      
-      # Check imps (single item - combine on one line)
+
+      # Check imps
       imp_list=$(get_level_imps "$level")
+      had_imps=0
       if [ -n "$imp_list" ]; then
-        if ! validate_spells --quiet --imps $imp_list 2>/dev/null; then
-          missing=$(validate_spells --imps --missing-only $imp_list)
-          printf '  %s✗%s Imps: Missing: %s\n' "$_red" "$_reset" "$missing"
+        had_imps=1
+        new_imp_list=""
+        for imp in $imp_list; do
+          case " ${_banish_seen_imps} " in
+            *" ${imp} "*) ;;
+            *)
+              new_imp_list="${new_imp_list}${new_imp_list:+ }${imp}"
+              _banish_seen_imps="${_banish_seen_imps}${_banish_seen_imps:+ }${imp}"
+              ;;
+          esac
+        done
+        imp_list=$new_imp_list
+      fi
+      if [ -n "$imp_list" ]; then
+        if ! eval "validate_spells --quiet --imps $imp_list" 2>/dev/null; then
+          missing=$(eval "validate_spells --imps --missing-only $imp_list" 2>/dev/null || true)
+          case "$missing" in
+            *" "*) label="Imps" ;;
+            *) label="Imp" ;;
+          esac
+          printf '  %s✗%s %s: Missing: %s\n' "$_red" "$_reset" "$label" "$missing"
           return 1
         fi
-        printf '  %s✓%s Imps: All found\n' "$_green" "$_reset"
+        printf '  Imps:\n'
+        imp_output=$(eval "validate_spells --imps --show-status $imp_list" 2>&1) || true
+        if [ -n "$imp_output" ]; then
+          printf '%s\n' "$imp_output" | sed 's/^/    /'
+        else
+          printf '    %s(no imp status available)%s\n' "$_red" "$_reset"
+        fi
+      elif [ "$had_imps" -eq 1 ]; then
+        printf '  Imps:\n'
+        printf '    (all listed earlier)\n'
+      else
+        printf '  Imps:\n'
+        printf '    (none)\n'
       fi
       ;;
   esac
@@ -438,6 +545,12 @@ if [ "$only_this_level" -eq 1 ]; then
   printf '\nValidating Level %d only: %s\n' "$target_level" "$(banish_level_name "$target_level")"
 else
   printf '\nValidating through Level %d: %s\n' "$target_level" "$(banish_level_name "$target_level")"
+fi
+
+# Require core validator before level checks
+if ! command -v validate_spells >/dev/null 2>&1; then
+  printf '%s\n' "banish: validate-spells not loaded (run invoke-wizardry or reload wizardry)" >&2
+  return 1
 fi
 
 # Run each level from 0 to target_level (or just target_level if --only)

--- a/spells/system/validate-spells
+++ b/spells/system/validate-spells
@@ -352,9 +352,17 @@ fi
 
 if [ -n "$missing" ]; then
   if [ "$validate_imps" -eq 1 ]; then
-    printf 'Missing imps: %s\n' "$missing" >&2
+    case "$missing" in
+      *" "*) label="imps" ;;
+      *) label="imp" ;;
+    esac
+    printf 'Missing %s: %s\n' "$label" "$missing" >&2
   else
-    printf 'Missing spells: %s\n' "$missing" >&2
+    case "$missing" in
+      *" "*) label="spells" ;;
+      *) label="spell" ;;
+    esac
+    printf 'Missing %s: %s\n' "$label" "$missing" >&2
   fi
   return 1
 fi


### PR DESCRIPTION
### Motivation
- Ensure higher banish levels report the imps they introduce instead of showing "none" by aligning `get_level_imps` with documented `SPELL_LEVELS` entries. 
- Avoid repeatedly reporting the same imp across multiple levels by deduplicating imps as levels are processed. 
- Make `banish` error early and consistently when the core validator is not available and standardize how `validate_spells` is invoked. 
- Improve user-facing wording by using correct singular/plural labels when reporting missing `spell(s)` and `imp(s)`.

### Description
- Added per-level imp lists to `spells/.imps/sys/spell-levels` for levels 2, 3, 5, 6, 7, 9, 10, and 13 to match the documented `Imps Introduced` entries. 
- Revamped `spells/system/banish` to rename `show_usage` -> `banish_usage`, introduce `_banish_seen_imps` plus per-level dedupe logic that builds `new_imp_list`, always print an `Imps:` section for each level, and show `(all listed earlier)` or `(none)` where appropriate. 
- Standardized validator calls in `banish` to use `eval "validate_spells ..."`, added an early `command -v validate_spells` check to fail fast when the validator is not loaded, and adjusted spell/imp status output formatting. 
- Updated `spells/system/validate-spells` to choose singular vs plural labels for missing items using a `case` selection and print `Missing spell(s)/imp(s)` accordingly.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952b0d9244c83208eab9ed09440e130)