### PR TITLE
Implement robust pluralize imp and wire banish to use counts

### DIFF
--- a/spells/.imps/text/pluralize
+++ b/spells/.imps/text/pluralize
@@ -1,0 +1,172 @@
+#!/bin/sh
+# pluralize WORD COUNT [PLURAL] - pluralize WORD based on COUNT.
+# If PLURAL is provided, it is used when COUNT != 1.
+# Otherwise, applies English pluralization rules with common irregulars.
+# Example: pluralize "spell" 1  # -> spell
+# Example: pluralize "spell" 2  # -> spells
+set -eu
+
+pluralize() {
+  if [ "$#" -lt 2 ]; then
+    printf '%s\n' "pluralize: WORD COUNT [PLURAL]" >&2
+    return 2
+  fi
+
+  _pluralize_word=$1
+  _pluralize_count=$2
+  _pluralize_plural=${3-}
+
+  if [ "$_pluralize_count" -eq 1 ]; then
+    printf '%s' "$_pluralize_word"
+    return 0
+  fi
+
+  if [ -n "$_pluralize_plural" ]; then
+    printf '%s' "$_pluralize_plural"
+    return 0
+  fi
+
+  case "$_pluralize_word" in
+    child) printf '%s' children ;;
+    person) printf '%s' people ;;
+    man) printf '%s' men ;;
+    woman) printf '%s' women ;;
+    mouse) printf '%s' mice ;;
+    goose) printf '%s' geese ;;
+    tooth) printf '%s' teeth ;;
+    foot) printf '%s' feet ;;
+    louse) printf '%s' lice ;;
+    ox) printf '%s' oxen ;;
+    die) printf '%s' dice ;;
+    cactus) printf '%s' cacti ;;
+    focus) printf '%s' foci ;;
+    fungus) printf '%s' fungi ;;
+    nucleus) printf '%s' nuclei ;;
+    syllabus) printf '%s' syllabi ;;
+    analysis) printf '%s' analyses ;;
+    diagnosis) printf '%s' diagnoses ;;
+    synopsis) printf '%s' synopses ;;
+    thesis) printf '%s' theses ;;
+    crisis) printf '%s' crises ;;
+    phenomenon) printf '%s' phenomena ;;
+    criterion) printf '%s' criteria ;;
+    datum) printf '%s' data ;;
+    medium) printf '%s' media ;;
+    bacterium) printf '%s' bacteria ;;
+    curriculum) printf '%s' curricula ;;
+    memorandum) printf '%s' memoranda ;;
+    stadium) printf '%s' stadia ;;
+    addendum) printf '%s' addenda ;;
+    stratum) printf '%s' strata ;;
+    bureau) printf '%s' bureaux ;;
+    index) printf '%s' indices ;;
+    appendix) printf '%s' appendices ;;
+    matrix) printf '%s' matrices ;;
+    vertex) printf '%s' vertices ;;
+    vortex) printf '%s' vortices ;;
+    axis) printf '%s' axes ;;
+    basis) printf '%s' bases ;;
+    oasis) printf '%s' oases ;;
+    thesis) printf '%s' theses ;;
+    fungus) printf '%s' fungi ;;
+    radius) printf '%s' radii ;;
+    stimulus) printf '%s' stimuli ;;
+    alumnus) printf '%s' alumni ;;
+    alumna) printf '%s' alumnae ;;
+    vertebra) printf '%s' vertebrae ;;
+    formula) printf '%s' formulae ;;
+    antenna) printf '%s' antennae ;;
+    nebula) printf '%s' nebulae ;;
+    millennium) printf '%s' millennia ;;
+    genus) printf '%s' genera ;;
+    corpus) printf '%s' corpora ;;
+    opus) printf '%s' opera ;;
+    status) printf '%s' statuses ;;
+    bus) printf '%s' buses ;;
+    axis) printf '%s' axes ;;
+    alias) printf '%s' aliases ;;
+    embargo) printf '%s' embargoes ;;
+    hero) printf '%s' heroes ;;
+    potato) printf '%s' potatoes ;;
+    tomato) printf '%s' tomatoes ;;
+    echo) printf '%s' echoes ;;
+    torpedo) printf '%s' torpedoes ;;
+    veto) printf '%s' vetoes ;;
+    calf) printf '%s' calves ;;
+    leaf) printf '%s' leaves ;;
+    life) printf '%s' lives ;;
+    loaf) printf '%s' loaves ;;
+    self) printf '%s' selves ;;
+    elf) printf '%s' elves ;;
+    shelf) printf '%s' shelves ;;
+    wolf) printf '%s' wolves ;;
+    knife) printf '%s' knives ;;
+    wife) printf '%s' wives ;;
+    thief) printf '%s' thieves ;;
+    scarf) printf '%s' scarves ;;
+    hoof) printf '%s' hooves ;;
+    dwarf) printf '%s' dwarves ;;
+    wharf) printf '%s' wharves ;;
+    fish) printf '%s' fish ;;
+    sheep) printf '%s' sheep ;;
+    deer) printf '%s' deer ;;
+    series) printf '%s' series ;;
+    species) printf '%s' species ;;
+    aircraft) printf '%s' aircraft ;;
+    moose) printf '%s' moose ;;
+    salmon) printf '%s' salmon ;;
+    trout) printf '%s' trout ;;
+    bison) printf '%s' bison ;;
+    means) printf '%s' means ;;
+    news) printf '%s' news ;;
+    police) printf '%s' police ;;
+    cattle) printf '%s' cattle ;;
+    *man)
+      printf '%s' "${_pluralize_word%man}men"
+      ;;
+    *mouse)
+      printf '%s' "${_pluralize_word%mouse}mice"
+      ;;
+    *goose)
+      printf '%s' "${_pluralize_word%goose}geese"
+      ;;
+    *tooth)
+      printf '%s' "${_pluralize_word%tooth}teeth"
+      ;;
+    *foot)
+      printf '%s' "${_pluralize_word%foot}feet"
+      ;;
+    *louse)
+      printf '%s' "${_pluralize_word%louse}lice"
+      ;;
+    *[sxz]|*ch|*sh)
+      printf '%s' "${_pluralize_word}es"
+      ;;
+    *[!aeiou]y)
+      printf '%s' "${_pluralize_word%y}ies"
+      ;;
+    *fe)
+      printf '%s' "${_pluralize_word%fe}ves"
+      ;;
+    *f)
+      printf '%s' "${_pluralize_word%f}ves"
+      ;;
+    *[!aeiou]o)
+      printf '%s' "${_pluralize_word}es"
+      ;;
+    *us)
+      printf '%s' "${_pluralize_word}es"
+      ;;
+    *is)
+      printf '%s' "${_pluralize_word%is}es"
+      ;;
+    *)
+      printf '%s' "${_pluralize_word}s"
+      ;;
+  esac
+}
+
+# Self-execute when run directly (not sourced)
+case "$0" in
+  */pluralize) pluralize "$@" ;;
+esac

--- a/spells/system/banish
+++ b/spells/system/banish
@@ -214,6 +214,7 @@ _red="${_esc}[31m"
 _reset="${_esc}[0m"
 
 _banish_seen_imps=""
+_banish_pluralize="${WIZARDRY_DIR}/spells/.imps/text/pluralize"
 
 # Run level-specific checks and actions using case statement
 banish_process_level() {
@@ -317,10 +318,9 @@ banish_process_level() {
       if [ -n "$spell_list" ]; then
         if ! eval "validate_spells --quiet $spell_list" 2>/dev/null; then
           missing=$(eval "validate_spells --missing-only $spell_list" 2>/dev/null || true)
-          case "$missing" in
-            *" "*) label="Spells" ;;
-            *) label="Spell" ;;
-          esac
+          # shellcheck disable=SC2086
+          set -- $missing
+          label=$("$_banish_pluralize" "Spell" "$#" "Spells")
           printf '  %s✗%s %s: Missing: %s\n' "$_red" "$_reset" "$label" "$missing"
           return 1
         fi
@@ -351,10 +351,9 @@ banish_process_level() {
       if [ -n "$imp_list" ]; then
         if ! eval "validate_spells --quiet --imps $imp_list" 2>/dev/null; then
           missing=$(eval "validate_spells --imps --missing-only $imp_list" 2>/dev/null || true)
-          case "$missing" in
-            *" "*) label="Imps" ;;
-            *) label="Imp" ;;
-          esac
+          # shellcheck disable=SC2086
+          set -- $missing
+          label=$("$_banish_pluralize" "Imp" "$#" "Imps")
           printf '  %s✗%s %s: Missing: %s\n' "$_red" "$_reset" "$label" "$missing"
           return 1
         fi
@@ -399,10 +398,9 @@ banish_process_level() {
       if [ -n "$spell_list" ]; then
         if ! eval "validate_spells --quiet $spell_list" 2>/dev/null; then
           missing=$(eval "validate_spells --missing-only $spell_list" 2>/dev/null || true)
-          case "$missing" in
-            *" "*) label="Spells" ;;
-            *) label="Spell" ;;
-          esac
+          # shellcheck disable=SC2086
+          set -- $missing
+          label=$("$_banish_pluralize" "Spell" "$#" "Spells")
           printf '  %s✗%s %s: Missing: %s\n' "$_red" "$_reset" "$label" "$missing"
           return 1
         fi
@@ -435,10 +433,9 @@ banish_process_level() {
       if [ -n "$imp_list" ]; then
         if ! eval "validate_spells --quiet --imps $imp_list" 2>/dev/null; then
           missing=$(eval "validate_spells --imps --missing-only $imp_list" 2>/dev/null || true)
-          case "$missing" in
-            *" "*) label="Imps" ;;
-            *) label="Imp" ;;
-          esac
+          # shellcheck disable=SC2086
+          set -- $missing
+          label=$("$_banish_pluralize" "Imp" "$#" "Imps")
           printf '  %s✗%s %s: Missing: %s\n' "$_red" "$_reset" "$label" "$missing"
           return 1
         fi
@@ -476,10 +473,9 @@ banish_process_level() {
       if [ -n "$spell_list" ]; then
         if ! eval "validate_spells --quiet $spell_list" 2>/dev/null; then
           missing=$(eval "validate_spells --missing-only $spell_list" 2>/dev/null || true)
-          case "$missing" in
-            *" "*) label="Spells" ;;
-            *) label="Spell" ;;
-          esac
+          # shellcheck disable=SC2086
+          set -- $missing
+          label=$("$_banish_pluralize" "Spell" "$#" "Spells")
           printf '  %s✗%s %s: Missing: %s\n' "$_red" "$_reset" "$label" "$missing"
           return 1
         fi
@@ -512,10 +508,9 @@ banish_process_level() {
       if [ -n "$imp_list" ]; then
         if ! eval "validate_spells --quiet --imps $imp_list" 2>/dev/null; then
           missing=$(eval "validate_spells --imps --missing-only $imp_list" 2>/dev/null || true)
-          case "$missing" in
-            *" "*) label="Imps" ;;
-            *) label="Imp" ;;
-          esac
+          # shellcheck disable=SC2086
+          set -- $missing
+          label=$("$_banish_pluralize" "Imp" "$#" "Imps")
           printf '  %s✗%s %s: Missing: %s\n' "$_red" "$_reset" "$label" "$missing"
           return 1
         fi


### PR DESCRIPTION
### Motivation
- Replace the previous word-count-based pluralization with a reusable `pluralize WORD COUNT [PLURAL]` interface that chooses singular/plural by numeric `COUNT`.
- Provide comprehensive English pluralization handling (common, uncommon, and many irregular/idiosyncratic forms) so labels read naturally.
- Eliminate ad-hoc `case` logic in `banish` for single vs plural labels and make label selection consistent and localizable through a pluralizer imp.

### Description
- Add `spells/.imps/text/pluralize`, implementing `pluralize WORD COUNT [PLURAL]` with an extensive irregulars table and pattern rules and preserving an optional explicit `PLURAL` argument.
- Update `spells/system/banish` to set `_banish_pluralize` to the new imp and replace inline `case`-based label selection with `set -- $missing` and calls to `"$_banish_pluralize"` to compute the correct label.
- Add `# shellcheck disable=SC2086` where `set -- $missing` intentionally expands words into positional parameters.
- Keep existing behavior when callers pass an explicit plural form and add self-execute support in the `pluralize` imp for direct invocation.

### Testing
- No automated tests were run for this change.
- No CI jobs were executed as part of this rollout.
- Manual execution of the `pluralize` script was not performed in this run.
- Existing runtime behavior in `banish` was updated but not validated by automated tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952c229636083209695dc6f8faf3479)