### PR TITLE
Format spell status lines and clarify banish imp messages

### DIFF
--- a/spells/system/banish
+++ b/spells/system/banish
@@ -351,9 +351,7 @@ banish_process_level() {
       if [ -n "$imp_list" ]; then
         if ! eval "validate_spells --quiet --imps $imp_list" 2>/dev/null; then
           missing=$(eval "validate_spells --imps --missing-only $imp_list" 2>/dev/null || true)
-          missing_count=$("$_banish_count_words" "$missing")
-          label=$("$_banish_pluralize" "Imp" "$missing_count" "Imps")
-          printf '  %s✗%s %s: Missing: %s\n' "$_red" "$_reset" "$label" "$missing"
+          printf '  %s✗%s Missing imps: %s\n' "$_red" "$_reset" "$missing"
           return 1
         fi
         printf '  Imps:\n'
@@ -431,9 +429,7 @@ banish_process_level() {
       if [ -n "$imp_list" ]; then
         if ! eval "validate_spells --quiet --imps $imp_list" 2>/dev/null; then
           missing=$(eval "validate_spells --imps --missing-only $imp_list" 2>/dev/null || true)
-          missing_count=$("$_banish_count_words" "$missing")
-          label=$("$_banish_pluralize" "Imp" "$missing_count" "Imps")
-          printf '  %s✗%s %s: Missing: %s\n' "$_red" "$_reset" "$label" "$missing"
+          printf '  %s✗%s Missing imps: %s\n' "$_red" "$_reset" "$missing"
           return 1
         fi
         printf '  Imps:\n'
@@ -445,7 +441,7 @@ banish_process_level() {
         fi
       elif [ "$had_imps" -eq 1 ]; then
         printf '  Imps:\n'
-        printf '    (all listed earlier)\n'
+        printf '    %s✓%s No new imps.\n' "$_green" "$_reset"
       else
         printf '  Imps:\n'
         printf '    (none)\n'
@@ -504,9 +500,7 @@ banish_process_level() {
       if [ -n "$imp_list" ]; then
         if ! eval "validate_spells --quiet --imps $imp_list" 2>/dev/null; then
           missing=$(eval "validate_spells --imps --missing-only $imp_list" 2>/dev/null || true)
-          missing_count=$("$_banish_count_words" "$missing")
-          label=$("$_banish_pluralize" "Imp" "$missing_count" "Imps")
-          printf '  %s✗%s %s: Missing: %s\n' "$_red" "$_reset" "$label" "$missing"
+          printf '  %s✗%s Missing imps: %s\n' "$_red" "$_reset" "$missing"
           return 1
         fi
         printf '  Imps:\n'
@@ -518,7 +512,7 @@ banish_process_level() {
         fi
       elif [ "$had_imps" -eq 1 ]; then
         printf '  Imps:\n'
-        printf '    (all listed earlier)\n'
+        printf '    %s✓%s No new imps.\n' "$_green" "$_reset"
       else
         printf '  Imps:\n'
         printf '    (none)\n'

--- a/spells/system/validate-spells
+++ b/spells/system/validate-spells
@@ -257,19 +257,28 @@ if [ "$validate_imps" -eq 0 ] && [ "$quiet" -eq 0 ] && [ "$show_status" -eq 1 ];
   if [ -n "$spell_loaded" ]; then
     spell_loaded_count=$("$_vs_count_words" "$spell_loaded")
     label=$("$_vs_pluralize" "spell" "$spell_loaded_count" "spells")
-    printf '\033[32m✓\033[0m Loaded %s: %s\n' "$label" "$spell_loaded"
+    printf '\033[32m✓\033[0m Loaded %s\n' "$label"
+    for spell in $spell_loaded; do
+      printf '  \033[32m✓\033[0m %s\n' "$spell"
+    done
   fi
 
   if [ -n "$spell_available" ]; then
     spell_available_count=$("$_vs_count_words" "$spell_available")
     label=$("$_vs_pluralize" "spell" "$spell_available_count" "spells")
-    printf '\033[34m●\033[0m Available %s: %s\n' "$label" "$spell_available"
+    printf '\033[34m●\033[0m Available %s\n' "$label"
+    for spell in $spell_available; do
+      printf '  \033[34m●\033[0m %s\n' "$spell"
+    done
   fi
 
   if [ -n "$spell_unavailable" ]; then
     spell_unavailable_count=$("$_vs_count_words" "$spell_unavailable")
     label=$("$_vs_pluralize" "spell" "$spell_unavailable_count" "spells")
-    printf '\033[31m✗\033[0m Unavailable %s: %s\n' "$label" "$spell_unavailable"
+    printf '\033[31m✗\033[0m Missing %s\n' "$label"
+    for spell in $spell_unavailable; do
+      printf '  \033[31m✗\033[0m %s\n' "$spell"
+    done
   fi
 fi
 


### PR DESCRIPTION
### Motivation
- Improve readability of spell status output by listing spells one-per-line under their headings with icons. 
- Make banish imp output clearer by using the phrase `Missing imps:` when imps are absent and a concise `✓ No new imps.` when there are no new imps for a level. 
- Avoid long inline lists in grouped output so headings and items are easier to scan. 
- Keep imps output behavior consistent across levels in `banish`.

### Description
- Updated `spells/system/validate-spells` to print `Loaded`, `Available`, and `Missing` spell headings and then list each spell on its own indented line prefixed with the appropriate icon. 
- Changed the unavailable-spell heading from `Unavailable` to `Missing` and emit individual `✗` lines for each missing spell. 
- Adjusted `spells/system/banish` to emit `Missing imps: <list>` for missing imps and to print `✓ No new imps.` (green check) when a level has no new imps to report. 
- Kept other grouped imp/spell status behavior intact while improving the presentation.

### Testing
- No automated tests were run as part of this change. 
- Changes were limited to output formatting in `spells/system/validate-spells` and `spells/system/banish` and should be safe to review via manual invocation. 
- Manual inspection of diffs confirms the new per-line spell listing and the new `Missing imps` / `No new imps.` messages. 
- Recommend running `validate-spells --show-status` and `banish` in a dev environment to visually verify output formatting.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952c811b1648320823b36dbd3b74b98)