### PR TITLE
banish: add `all` target, default to level 2, and improve success messaging

### DIFF
--- a/.github/SPIRAL_DEBUG.md
+++ b/.github/SPIRAL_DEBUG.md
@@ -40,8 +40,8 @@ These are the essential components that MUST work before we proceed:
 4. word-of-binding finds the spell/imp and either sources or executes it
 
 **Pre-loaded components**:
-- **Imps**: require, require-wizardry, castable, env-clear, temp-file, cleanup-file, has, die, warn, fail, say
-- **Spells**: menu, await-keypress, move-cursor, fathom-cursor, fathom-terminal, cursor-blink, colors, banish
+- **Imps**: all imps up through level 2 (from `spells/.imps/sys/spell-levels`)
+- **Spells**: all spells up through level 2 (from `spells/.imps/sys/spell-levels`)
 
 **Hotloaded** (via command_not_found_handle):
 - All other spells and imps load on first use
@@ -163,6 +163,11 @@ After all features work:
   - `bash -lc 'source spells/.imps/sys/invoke-wizardry; menu --help | head -n 3'` → usage text prints.
   - `bash -lc 'source spells/.imps/sys/invoke-wizardry; command -v word_of_binding'` → function available.
   - Note: full interactive menu run requires a TTY; not exercised in this container.
+
+### 2025-12-28: Preload all level 0-2 spells and imps
+
+- **Change**: `invoke-wizardry` now preloads every spell and imp defined through level 2 using `spells/.imps/sys/spell-levels`.
+- **Why**: keeps the preload set aligned with spell level definitions while still supporting the spiral debug minimal boot.
 
 ### 2025-12-28: Remove leading underscores from imp true-names
 

--- a/spells/.imps/sys/invoke-wizardry
+++ b/spells/.imps/sys/invoke-wizardry
@@ -97,62 +97,37 @@ invoke_wizardry() {
     return 1
   fi
   
-  # Pre-load essential imps needed by menu
-  # These are from sys/, out/, fs/, cond/ families
-  _iw_debug "Pre-loading essential imps"
-  for _imp_name in \
-    require \
-    require-wizardry \
-    castable \
-    env-clear \
-    temp-file \
-    cleanup-file \
-    has \
-    die \
-    warn \
-    fail \
-    say; do
-    # Search for imp in all families
-    for _family_dir in "$WIZARDRY_DIR"/spells/.imps/*; do
-      [ -d "$_family_dir" ] || continue
-      _imp_file="$_family_dir/$_imp_name"
-      if [ -f "$_imp_file" ]; then
-        if command -v word_of_binding >/dev/null 2>&1; then
-          word_of_binding "$_imp_name" 2>/dev/null || :
-        fi
-        break
+  _iw_spell_levels="$WIZARDRY_DIR/spells/.imps/sys/spell-levels"
+  if [ -r "$_iw_spell_levels" ]; then
+    # shellcheck disable=SC1090
+    . "$_iw_spell_levels"
+  fi
+  if ! command -v get_level_imps >/dev/null 2>&1; then
+    get_level_imps() { printf ''; }
+  fi
+  if ! command -v get_level_spells >/dev/null 2>&1; then
+    get_level_spells() { printf ''; }
+  fi
+
+  # Pre-load all spells/imps through level 2
+  _iw_debug "Pre-loading spells and imps through level 2"
+  for _iw_level in 0 1 2; do
+    _iw_level_imps=$(get_level_imps "$_iw_level")
+    for _imp_entry in $_iw_level_imps; do
+      _imp_name=${_imp_entry##*/}
+      if command -v word_of_binding >/dev/null 2>&1; then
+        word_of_binding "$_imp_name" 2>/dev/null || :
       fi
     done
-  done
-  
-  # Pre-load menu and its helper spell dependencies
-  _iw_debug "Pre-loading essential spells"
-  for _spell_name in \
-    menu \
-    await-keypress \
-    move-cursor \
-    fathom-cursor \
-    fathom-terminal \
-    require-command \
-    cursor-blink \
-    colors \
-    banish \
-    validate-spells; do
-    # Search for spell in all categories
-    for _spell_dir in "$WIZARDRY_DIR"/spells/*; do
-      [ -d "$_spell_dir" ] || continue
-      case "$_spell_dir" in */.imps|*/.arcana) continue ;; esac
-      _spell_file="$_spell_dir/$_spell_name"
-      if [ -f "$_spell_file" ]; then
-        _iw_debug "Loading spell: $_spell_name"
-        if command -v word_of_binding >/dev/null 2>&1 \
-          && word_of_binding "$_spell_name" 2>/dev/null; then
-          _iw_status="✓ Loaded"
-        else
-          _iw_status="✗ Failed"
-        fi
-        _iw_debug "  $_iw_status: $_spell_name"
-        break
+
+    _iw_level_spells=$(get_level_spells "$_iw_level")
+    for _spell_entry in $_iw_level_spells; do
+      case "$_spell_entry" in
+        *:*) _spell_name=${_spell_entry%%:*} ;;
+        *) _spell_name=$_spell_entry ;;
+      esac
+      if command -v word_of_binding >/dev/null 2>&1; then
+        word_of_binding "$_spell_name" 2>/dev/null || :
       fi
     done
   done

--- a/spells/system/banish
+++ b/spells/system/banish
@@ -6,7 +6,7 @@
 
 banish_usage() {
   cat <<'USAGE'
-Usage: banish [LEVEL] [OPTIONS]
+Usage: banish [LEVEL|all] [OPTIONS]
 
 Validate wizardry at the specified spell level, checking assumptions, 
 self-healing issues, and running tests. Each level builds on previous levels.
@@ -15,7 +15,8 @@ NOTE: Banish requires wizardry to be installed. Run ./install first.
 See .github/SPELL_LEVELS.md for complete level documentation.
 
 Arguments:
-  LEVEL                 Spell level to validate (0-27, default: 1)
+  LEVEL                 Spell level to validate (0-27, default: 2)
+  all                   Validate through the highest available level
                         Level 0: POSIX & platform foundation
                         Level 1: Wizardry installation
                         Level 2: Menu system
@@ -50,9 +51,10 @@ Exit Codes:
   2  Invalid usage
 
 Examples:
-  banish                    # Validate through level 1 (default - levels 0-1: POSIX + wizardry)
+  banish                    # Validate through level 2 (default - levels 0-2: POSIX + wizardry + menu)
   banish 0                  # Validate level 0 only (POSIX foundation)
   banish 2                  # Validate through level 2 (levels 0-2: POSIX + wizardry + menu)
+  banish all                # Validate through the highest available level
   banish 4 --no-tests       # Validate through level 4, skip tests
   banish 1 --no-heal        # Validate through level 1, only report issues
 USAGE
@@ -127,16 +129,21 @@ fi
 export WIZARDRY_DIR
 
 # Parse arguments
-target_level=1
+target_level=2
+target_level_all=0
 skip_tests=0
 skip_heal=0
 only_this_level=0
 
-# First, check if first arg is a number (the level)
+# First, check if first arg is a number (the level) or "all"
 if [ "$#" -gt 0 ]; then
   case "$1" in
     [0-9]|[0-9][0-9])
       target_level=$1
+      shift
+      ;;
+    all)
+      target_level_all=1
       shift
       ;;
   esac
@@ -172,6 +179,10 @@ while [ "$#" -gt 0 ]; do
           target_level=$1
           shift
           ;;
+        all)
+          target_level_all=1
+          shift
+          ;;
         *)
           printf 'Error: unexpected argument: %s\n' "$1" >&2
           banish_usage >&2
@@ -181,13 +192,6 @@ while [ "$#" -gt 0 ]; do
       ;;
   esac
 done
-
-# Validate level
-if [ "$target_level" -lt 0 ] || [ "$target_level" -gt 27 ]; then
-  printf 'Error: level must be 0-27, got: %s\n' "$target_level" >&2
-  banish_usage >&2
-  return 2
-fi
 
 # Source shared spell level definitions from sys imp
 # This file is shared by banish, test-magic, and demo-magic
@@ -205,6 +209,29 @@ else
     get_level_imps() { printf '' ; }
     banish_level_name() { printf 'Unknown' ; }
   fi
+fi
+
+banish_max_level() {
+  if [ -d "${WIZARDRY_DIR}/spells/.arcana" ]; then
+    for _arcana_entry in "${WIZARDRY_DIR}"/spells/.arcana/*; do
+      [ -e "$_arcana_entry" ] || continue
+      printf '%s' 27
+      return 0
+    done
+  fi
+  printf '%s' 26
+  return 0
+}
+
+if [ "$target_level_all" -eq 1 ]; then
+  target_level=$(banish_max_level)
+fi
+
+# Validate level
+if [ "$target_level" -lt 0 ] || [ "$target_level" -gt 27 ]; then
+  printf 'Error: level must be 0-27, got: %s\n' "$target_level" >&2
+  banish_usage >&2
+  return 2
 fi
 
 # Color codes (inline to avoid dependency)
@@ -552,7 +579,11 @@ while [ "$current_level" -le "$target_level" ]; do
 done
 
 # Final success message
-printf '\n%s✓%s All validation checks passed\n' "$_green" "$_reset"
+if [ "$target_level_all" -eq 1 ]; then
+  printf '\n%s✓%s Banished all (Level %d)\n' "$_green" "$_reset" "$target_level"
+else
+  printf '\n%s✓%s Banished to Level %d\n' "$_green" "$_reset" "$target_level"
+fi
 
 return 0
 }

--- a/spells/system/validate-spells
+++ b/spells/system/validate-spells
@@ -129,6 +129,92 @@ spell_loaded=""
 spell_available=""
 spell_unavailable=""
 
+validate_entry() {
+  entry_spell=$1
+  entry_path=$2
+  entry_status_override=$3
+
+  # Determine function name
+  if [ "$validate_imps" -eq 1 ]; then
+    # For imps, extract just the name part after the family/
+    # Keep hyphens as-is (imps use hyphenated names)
+    func_name=$(printf '%s' "$entry_spell" | sed 's|.*/||')
+  else
+    # For spells, use hyphenated name as-is
+    func_name=$(printf '%s' "$entry_spell" | sed 's|.*/||')
+  fi
+
+  # Check if loaded as function (try both hyphenated and underscored versions)
+  is_loaded=0
+  if [ -n "$entry_status_override" ]; then
+    if [ "$entry_status_override" = "L" ]; then
+      is_loaded=1
+    fi
+  else
+    for name_variant in "$func_name" "$(printf '%s' "$func_name" | tr '-' '_')"; do
+      if command -v "$name_variant" >/dev/null 2>&1; then
+        func_type=$(type "$name_variant" 2>/dev/null || true)
+        case "$func_type" in
+          *"function"*|*"shell function"*)
+            is_loaded=1
+            break
+            ;;
+        esac
+      fi
+    done
+  fi
+
+  if [ -f "$entry_path" ]; then
+    found_count=$((found_count + 1))
+
+    if [ "$is_loaded" -eq 1 ]; then
+      loaded_count=$((loaded_count + 1))
+
+      # For imps with --show-status, store result for later output
+      if [ "$validate_imps" -eq 1 ] && [ "$show_status" -eq 1 ]; then
+        imp_name=$(printf '%s' "$entry_spell" | sed 's|.*/||')
+        # Format: status|name (status: L=loaded, A=available)
+        imp_results="${imp_results}${imp_results:+
+}L|${imp_name}"
+      elif [ "$quiet" -eq 0 ] && [ "$show_status" -eq 1 ]; then
+        # For spells, collect grouped output
+        spell_loaded="${spell_loaded}${spell_loaded:+ }${entry_spell}"
+      fi
+    else
+      available_count=$((available_count + 1))
+
+      # For imps with --show-status, store result for later output
+      if [ "$validate_imps" -eq 1 ] && [ "$show_status" -eq 1 ]; then
+        imp_name=$(printf '%s' "$entry_spell" | sed 's|.*/||')
+        # Format: status|name (status: L=loaded, A=available)
+        imp_results="${imp_results}${imp_results:+
+}A|${imp_name}"
+      elif [ "$quiet" -eq 0 ] && [ "$show_status" -eq 1 ]; then
+        # For spells, collect grouped output
+        spell_available="${spell_available}${spell_available:+ }${entry_spell}"
+      fi
+    fi
+
+    if [ "$quiet" -eq 0 ] && [ "$show_status" -eq 0 ]; then
+      if [ "$validate_imps" -eq 1 ]; then
+        printf '✓ Found imp: %s\n' "$entry_spell"
+      else
+        printf '✓ Found spell: %s\n' "$entry_spell"
+      fi
+    fi
+  else
+    missing="${missing:+$missing }$entry_spell"
+    if [ "$quiet" -eq 0 ] && [ "$show_status" -eq 1 ]; then
+      if [ "$validate_imps" -eq 1 ]; then
+        imp_name=$(printf '%s' "$entry_spell" | sed 's|.*/||')
+        imp_unavailable="${imp_unavailable}${imp_unavailable:+ }${imp_name}"
+      else
+        spell_unavailable="${spell_unavailable}${spell_unavailable:+ }${entry_spell}"
+      fi
+    fi
+  fi
+}
+
 for spell_info in "$@"; do
   status_override=""
   # Parse spell:dir format (or category:status:name for imps)
@@ -170,86 +256,22 @@ for spell_info in "$@"; do
   else
     spell_path="${WIZARDRY_DIR}/spells/$dir/$spell"
   fi
-  
-  # Determine function name
-  if [ "$validate_imps" -eq 1 ]; then
-    # For imps, extract just the name part after the family/
-    # Keep hyphens as-is (imps use hyphenated names)
-    func_name=$(printf '%s' "$spell" | sed 's|.*/||')
-  else
-    # For spells, use hyphenated name as-is
-    func_name=$(printf '%s' "$spell" | sed 's|.*/||')
-  fi
-  
-  # Check if loaded as function (try both hyphenated and underscored versions)
-  is_loaded=0
-  if [ -n "$status_override" ]; then
-    if [ "$status_override" = "L" ]; then
-      is_loaded=1
-    fi
-  else
-    for name_variant in "$func_name" "$(printf '%s' "$func_name" | tr '-' '_')"; do
-      if command -v "$name_variant" >/dev/null 2>&1; then
-        func_type=$(type "$name_variant" 2>/dev/null || true)
-        case "$func_type" in
-          *"function"*|*"shell function"*)
-            is_loaded=1
-            break
-            ;;
-        esac
-      fi
+
+  if [ "$validate_imps" -eq 1 ] && [ -d "$spell_path" ]; then
+    found_entry=0
+    for imp_file in "$spell_path"/*; do
+      [ -f "$imp_file" ] || continue
+      found_entry=1
+      entry_spell="${spell}/$(basename "$imp_file")"
+      validate_entry "$entry_spell" "$imp_file" ""
     done
+    if [ "$found_entry" -eq 0 ]; then
+      missing="${missing:+$missing }$spell"
+    fi
+    continue
   fi
-  
-  if [ -f "$spell_path" ]; then
-    found_count=$((found_count + 1))
-    
-    if [ "$is_loaded" -eq 1 ]; then
-      loaded_count=$((loaded_count + 1))
-      
-      # For imps with --show-status, store result for later output
-      if [ "$validate_imps" -eq 1 ] && [ "$show_status" -eq 1 ]; then
-        imp_name=$(printf '%s' "$spell" | sed 's|.*/||')
-        # Format: status|name (status: L=loaded, A=available)
-        imp_results="${imp_results}${imp_results:+
-}L|${imp_name}"
-      elif [ "$quiet" -eq 0 ] && [ "$show_status" -eq 1 ]; then
-        # For spells, collect grouped output
-        spell_loaded="${spell_loaded}${spell_loaded:+ }${spell}"
-      fi
-    else
-      available_count=$((available_count + 1))
-      
-      # For imps with --show-status, store result for later output
-      if [ "$validate_imps" -eq 1 ] && [ "$show_status" -eq 1 ]; then
-        imp_name=$(printf '%s' "$spell" | sed 's|.*/||')
-        # Format: status|name (status: L=loaded, A=available)
-        imp_results="${imp_results}${imp_results:+
-}A|${imp_name}"
-      elif [ "$quiet" -eq 0 ] && [ "$show_status" -eq 1 ]; then
-        # For spells, collect grouped output
-        spell_available="${spell_available}${spell_available:+ }${spell}"
-      fi
-    fi
-    
-    if [ "$quiet" -eq 0 ] && [ "$show_status" -eq 0 ]; then
-      if [ "$validate_imps" -eq 1 ]; then
-        printf '✓ Found imp: %s\n' "$spell"
-      else
-        printf '✓ Found spell: %s\n' "$spell"
-      fi
-    fi
-  else
-    missing="${missing:+$missing }$spell"
-    if [ "$quiet" -eq 0 ] && [ "$show_status" -eq 1 ]; then
-      if [ "$validate_imps" -eq 1 ]; then
-        imp_name=$(printf '%s' "$spell" | sed 's|.*/||')
-        imp_unavailable="${imp_unavailable}${imp_unavailable:+ }${imp_name}"
-      else
-        spell_unavailable="${spell_unavailable}${spell_unavailable:+ }${spell}"
-      fi
-    fi
-  fi
+
+  validate_entry "$spell" "$spell_path" "$status_override"
 done
 
 # Output grouped results for spells with --show-status


### PR DESCRIPTION
### Motivation
- Make the default `banish` target include the menu level (so common interactive features are validated by default).
- Provide a convenient `banish all` mode that validates through the highest available level and prints a clear, unambiguous success message.
- Keep preload and validation behavior aligned with canonical level definitions to improve startup reliability. 

### Description
- Update `spells/system/banish` to accept `LEVEL|all`, change the default `target_level` to `2`, add a `target_level_all` flag, and resolve `all` to a computed max via the new `banish_max_level()` helper. 
- Emit a distinct final success message when `--all` is used as `Banished all (Level %d)` and retain the per-level success wording for non-all runs. 
- Update `spells/.imps/sys/invoke-wizardry` to source `spells/.imps/sys/spell-levels` and preload all spells and imps for levels `0..2` via `word_of_binding`. 
- Refactor `spells/system/validate-spells` by adding a `validate_entry()` helper and iterating individual files inside imp directories so each imp file is validated and status/counts are accumulated per-file. 

### Testing
- No automated tests were executed for these changes. 
- (No automated test failures to report because none were run.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952d1206b48832080705291eeced564)