### PR TITLE
Complete banish level spell and imp mappings

### DIFF
--- a/spells/.imps/sys/spell-levels
+++ b/spells/.imps/sys/spell-levels
@@ -5,7 +5,7 @@
 get_level_spells() {
   case "$1" in
     0) printf 'detect-posix:divination detect-distro:divination verify-posix:system' ;;
-    1) printf 'banish:system' ;;
+    1) printf 'banish:system validate-spells:system' ;;
     2) printf 'menu fathom-terminal fathom-cursor move-cursor await-keypress cursor-blink colors main-menu:menu' ;;
     3) printf 'check-cd-hook:mud look:mud' ;;
     4) printf 'jump-to-marker:translocation mark-location:translocation' ;;
@@ -16,7 +16,7 @@ get_level_spells() {
     9) printf 'config:system logs:system package-managers:system' ;;
     10) printf 'test-spell:system test-magic:system logging-example wizard-eyes' ;;
     11) printf 'update-wizardry:system update-all:system kill-process:system' ;;
-    12) printf 'demo-magic:system verify-posix:system wizard-cast' ;;
+    12) printf 'demo-magic:system wizard-cast' ;;
     13) printf 'detect-rc-file:divination detect-magic:divination identify-room:divination' ;;
     14) printf 'decorate:mud select-player:mud check-command-not-found-hook:mud' ;;
     15) printf 'hash:crypto evoke-hash:crypto hashchant:crypto' ;;
@@ -37,15 +37,17 @@ get_level_spells() {
 }
 get_level_imps() {
   case "$1" in
-    1) printf 'sys/invoke-wizardry sys/require-wizardry sys/require sys/castable sys/env-clear sys/on-exit sys/clear-traps cond/has cond/there cond/is cond/empty cond/nonempty out/say out/warn out/die out/fail out/info out/step out/success out/debug fs/temp-file fs/temp-dir fs/cleanup-file fs/cleanup-dir input/tty-save input/tty-restore input/tty-raw input/read-line str/contains str/trim str/equals str/starts str/ends paths/here paths/parent paths/file-name paths/abs-path' ;;
-    2) printf 'menu/is-submenu menu/is-integer menu/category-title menu/exit-label' ;;
+    1) printf 'declare-globals sys/invoke-wizardry sys/invoke-wizardry-minimal-wob sys/invoke-thesaurus sys/require-wizardry sys/require sys/castable sys/word-of-binding sys/env-clear sys/env-or sys/on-exit sys/clear-traps sys/on sys/now sys/any sys/need sys/must sys/uncastable sys/where sys/autocast sys/ask-install-wizardry sys/clipboard-available sys/command-not-found-handler-zsh sys/nix-shell-add sys/nix-shell-remove sys/nix-shell-status sys/nix-rebuild sys/spell-levels cond/has cond/there cond/is cond/empty cond/nonempty cond/no cond/in-range cond/lacks cond/newer cond/full cond/gone cond/is-path cond/in-ancestry cond/is-posint cond/yes cond/given cond/older out/say out/warn out/die out/fail out/info out/step out/success out/debug out/ok out/heading-section out/heading-separator out/heading-simple out/usage-error out/first-of out/else out/print-pass out/print-fail out/disable-palette out/quiet fs/temp-file fs/temp-dir fs/cleanup-file fs/cleanup-dir input/tty-save input/tty-restore input/tty-raw input/read-line str/contains str/trim str/equals str/starts str/ends str/lower str/upper str/seeks str/differs str/matches paths/here paths/parent paths/file-name paths/abs-path paths/make paths/path paths/tilde-path paths/strip-trailing-slashes paths/norm-path paths/script-dir paths/temp text/pluralize text/count-words' ;;
+    2) printf 'menu/is-submenu menu/is-integer menu/category-title menu/exit-label menu/is-installable' ;;
     3) printf 'fs/xattr-helper-usable fs/xattr-list-keys fs/xattr-read-value' ;;
-    5) printf 'fs/backup menu/detect-trash text/read-file text/write-file text/lines text/each' ;;
-    6) printf 'input/select-input lex/parse lex/from lex/to' ;;
+    5) printf 'fs/backup fs/clip-copy fs/clip-paste fs/ensure-parent-dir menu/detect-trash text/read-file text/write-file text/lines text/each text/append text/count-chars text/make-indent text/drop text/last text/take text/skip text/first text/pick text/field' ;;
+    6) printf 'input/select-input lex/parse lex/from lex/to lex/and-then lex/into lex/then lex/disambiguate' ;;
     7) printf 'input/validate-command input/validate-name lex/and lex/or' ;;
-    9) printf 'fs/config-get fs/config-set fs/config-has fs/config-del' ;;
+    9) printf 'fs/config-get fs/config-set fs/config-has fs/config-del pkg/pkg-manager pkg/pkg-has pkg/pkg-install pkg/pkg-remove pkg/pkg-update pkg/pkg-upgrade' ;;
     10) printf 'test/boot/assert-error-contains test/boot/assert-failure test/boot/assert-file-contains test/boot/assert-output-contains test/boot/assert-path-exists test/boot/assert-path-missing test/boot/assert-status test/boot/assert-success test/boot/find-repo-root test/boot/finish-tests test/boot/init-test-counters test/boot/link-tools test/boot/make-fixture test/boot/make-tempdir test/boot/provide-basic-tools test/boot/record-failure-detail test/boot/report-result test/boot/run-both-patterns test/boot/run-bwrap test/boot/run-cmd test/boot/run-macos-sandbox test/boot/run-sourced-spell test/boot/run-spell test/boot/run-spell-in-dir test/boot/run-test-case test/boot/skip-if-compiled test/boot/skip-if-uncompiled test/boot/stub-nix-env test/boot/stub-pacman test/boot/test-fail test/boot/test-heading test/boot/test-lack test/boot/test-pass test/boot/test-skip test/boot/test-summary test/boot/write-apt-stub test/boot/write-command-stub test/boot/write-pkgin-stub test/boot/write-sudo-stub test/stub-cursor-blink test/stub-fathom-terminal test/stub-stty test/stub-await-keypress test/stub-fathom-cursor test/stub-move-cursor test/test-bootstrap sys/rc-add-line sys/rc-has-line sys/rc-remove-line' ;;
-    13) printf 'sys/os sys/term text/detect-indent-char text/detect-indent-width' ;;
+    11) printf 'fs/backup-nix-config' ;;
+    13) printf 'sys/os sys/term text/detect-indent-char text/detect-indent-width lang/possessive' ;;
+    18) printf 'fs/sed-inplace' ;;
     *) printf '' ;;
   esac
 }


### PR DESCRIPTION
### Motivation
- Ensure `banish` validates the environment correctly by making level spell lists complete and unambiguous.
- Make sure every spell and imp is assigned to exactly one banish level so `banish`, `test-magic`, and `demo-magic` behave deterministically.
- Surface missing helper imps so preloading and hotloading in `invoke-wizardry` can reliably bind commands.

### Description
- Updated `spells/.imps/sys/spell-levels` to add `validate-spells:system` to level `1` and remove a duplicate `verify-posix` listing from level `12`.
- Expanded and enumerated the `get_level_imps()` entries to include missing `sys/*`, `out/*`, `fs/*`, `text/*`, `lex/*`, `pkg/*`, and other helper imps and helpers at appropriate levels.
- Added several specific helpers to levels (e.g. `menu/is-installable`, `fs/backup-nix-config`, `fs/sed-inplace`, and many `text/` and `paths/` helpers) so listed spells have their declared imp dependencies present.
- Cleaned up lex helper listings and grouped commonly used helpers under the foundational level so `banish` can validate earlier levels reliably.

### Testing
- Ran repository validation scripts (Python checks) that compare actual `spells/` and `spells/.imps/` files against entries in `spells/.imps/sys/spell-levels`, and they reported no missing spells, no missing imps, and no duplicate listings after the change (tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952e2e638d48320bfb6329093f2147b)