### PR TITLE
Add opt-in BANISH_TRACE_XATTR tracing to banish xattr test

### DIFF
--- a/spells/wards/banish
+++ b/spells/wards/banish
@@ -1713,20 +1713,42 @@ HEREDOC_TEST
       tmp_xattr_test=$(mktemp "${tmp_root%/}/banish-xattr.XXXXXX" 2>/dev/null || printf '')
       if [ -n "$tmp_xattr_test" ]; then
         xattr_works=0
+        if [ "${BANISH_TRACE_XATTR:-0}" -eq 1 ]; then
+          printf '[banish-trace] xattr test file: %s\n' "$tmp_xattr_test" >&2
+          printf '[banish-trace] xattr helper detected: %s\n' "${xattr_helper:-none}" >&2
+        fi
         
         # Try to set an extended attribute
         if command -v xattr >/dev/null 2>&1; then
+          if [ "${BANISH_TRACE_XATTR:-0}" -eq 1 ]; then
+            printf '[banish-trace] running: xattr -w user.test value %s\n' "$tmp_xattr_test" >&2
+          fi
           if xattr -w user.test "value" "$tmp_xattr_test" 2>/dev/null; then
             # Verify we can read it back
+            if [ "${BANISH_TRACE_XATTR:-0}" -eq 1 ]; then
+              printf '[banish-trace] running: xattr -p user.test %s\n' "$tmp_xattr_test" >&2
+            fi
             if xattr -p user.test "$tmp_xattr_test" 2>/dev/null | grep -q "value"; then
               xattr_works=1
+            fi
+            if [ "${BANISH_TRACE_XATTR:-0}" -eq 1 ]; then
+              printf '[banish-trace] running: xattr -d user.test %s\n' "$tmp_xattr_test" >&2
             fi
             xattr -d user.test "$tmp_xattr_test" 2>/dev/null || :
           fi
         elif command -v setfattr >/dev/null 2>&1 && command -v getfattr >/dev/null 2>&1; then
+          if [ "${BANISH_TRACE_XATTR:-0}" -eq 1 ]; then
+            printf '[banish-trace] running: setfattr -n user.test -v value %s\n' "$tmp_xattr_test" >&2
+          fi
           if setfattr -n user.test -v "value" "$tmp_xattr_test" 2>/dev/null; then
+            if [ "${BANISH_TRACE_XATTR:-0}" -eq 1 ]; then
+              printf '[banish-trace] running: getfattr -n user.test %s\n' "$tmp_xattr_test" >&2
+            fi
             if getfattr -n user.test "$tmp_xattr_test" 2>/dev/null | grep -q "value"; then
               xattr_works=1
+            fi
+            if [ "${BANISH_TRACE_XATTR:-0}" -eq 1 ]; then
+              printf '[banish-trace] running: setfattr -x user.test %s\n' "$tmp_xattr_test" >&2
             fi
             setfattr -x user.test "$tmp_xattr_test" 2>/dev/null || :
           fi


### PR DESCRIPTION
### Motivation
- Pinpoint which extended-attribute helper and exact command run right before the mysterious exit code 139 during the level-8 xattr filesystem check so we can reproduce and diagnose the crash.

### Description
- Add conditional tracing in `spells/wards/banish` around the temporary xattr test that logs the test file path and detected helper.
- Emit the exact `xattr`, `xattr -p`, `xattr -d` and `setfattr`/`getfattr`/`setfattr -x` invocations to stderr when enabled so the last-run command is visible before a crash.
- Make tracing opt-in via the `BANISH_TRACE_XATTR` environment variable (default `0`, enable with `BANISH_TRACE_XATTR=1`).

### Testing
- No automated tests were executed for this change because it only adds optional debug logging.

[Codex Task](https://chatgpt.com/codex/tasks/task_e_696abf8a41f883209abbfe0861914b9b)
---

## 🔍 Latest Test Failures

**Updated:** 2026-01-16 23:15:16 UTC


### ❌ Unit tests - Ubuntu unit tests
```
2026-01-16T22:59:47.6414274Z ##[group]Run chmod +x spells/.arcana/mud/install-mud spells/.arcana/tor/setup-tor spells/.imps/fs/xattr-helper-usable spells/.imps/fs/xattr-list-keys spells/.imps/fs/xattr-read-value
2026-01-16T22:59:47.6416664Z [36;1mchmod +x spells/.arcana/mud/install-mud spells/.arcana/tor/setup-tor spells/.imps/fs/xattr-helper-usable spells/.imps/fs/xattr-list-keys spells/.imps/fs/xattr-read-value[0m
2026-01-16T22:59:47.6453725Z shell: /usr/bin/bash -e {0}
2026-01-16T22:59:47.6454258Z env:
2026-01-16T22:59:47.6454647Z   WIZARDRY_OS_LABEL: ubuntu
2026-01-16T22:59:47.6455134Z ##[endgroup]
2026-01-16T22:59:47.6587796Z ##[group]Run sudo apt-get update && sudo apt-get install -y bubblewrap uidmap attr file
2026-01-16T22:59:47.6589190Z [36;1msudo apt-get update && sudo apt-get install -y bubblewrap uidmap attr file[0m
2026-01-16T22:59:47.6620429Z shell: /usr/bin/bash -e {0}
2026-01-16T22:59:47.6620924Z env:
2026-01-16T22:59:47.6621320Z   WIZARDRY_OS_LABEL: ubuntu
2026-01-16T22:59:47.6621795Z ##[endgroup]
2026-01-16T22:59:47.7380416Z Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
2026-01-16T22:59:47.7720964Z Hit:2 http://azure.archive.ubuntu.com/ubuntu noble InRelease
2026-01-16T22:59:47.7739601Z Get:3 http://azure.archive.ubuntu.com/ubuntu noble-updates InRelease [126 kB]
2026-01-16T22:59:47.7742577Z Get:6 https://packages.microsoft.com/repos/azure-cli noble InRelease [3564 B]
2026-01-16T22:59:47.7782928Z Get:4 http://azure.archive.ubuntu.com/ubuntu noble-backports InRelease [126 kB]
2026-01-16T22:59:47.7799599Z Get:7 https://packages.microsoft.com/ubuntu/24.04/prod noble InRelease [3600 B]
2026-01-16T22:59:47.7824118Z Get:5 http://azure.archive.ubuntu.com/ubuntu noble-security InRelease [126 kB]
2026-01-16T22:59:47.9079819Z Get:8 https://packages.microsoft.com/repos/azure-cli noble/main amd64 Packages [1948 B]
2026-01-16T22:59:47.9543341Z Get:9 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 Packages [1694 kB]
2026-01-16T22:59:47.9714402Z Get:10 http://azure.archive.ubuntu.com/ubuntu noble-updates/main Translation-en [313 kB]
2026-01-16T22:59:47.9754540Z Get:11 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 Components [175 kB]
2026-01-16T22:59:47.9773589Z Get:12 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 c-n-f Metadata [15.9 kB]
2026-01-16T22:59:47.9785423Z Get:13 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 Packages [1514 kB]
2026-01-16T22:59:47.9870959Z Get:14 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe Translation-en [308 kB]
2026-01-16T22:59:47.9898216Z Get:15 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 Components [378 kB]
2026-01-16T22:59:47.9933347Z Get:16 http://azure.archive.ubuntu.com/ubuntu noble-updates/universe amd64 c-n-f Metadata [31.4 kB]
2026-01-16T22:59:47.9945783Z Get:17 http://azure.archive.ubuntu.com/ubuntu noble-updates/restricted amd64 Packages [2426 kB]
2026-01-16T22:59:48.0118381Z Get:18 http://azure.archive.ubuntu.com/ubuntu noble-updates/restricted Translation-en [554 kB]
2026-01-16T22:59:48.0595043Z Get:19 http://azure.archive.ubuntu.com/ubuntu noble-updates/restricted amd64 Components [212 B]
2026-01-16T22:59:48.0602226Z Get:25 https://packages.microsoft.com/ubuntu/24.04/prod noble/main amd64 Packages [80.6 kB]
2026-01-16T22:59:48.0609957Z Get:20 http://azure.archive.ubuntu.com/ubuntu noble-updates/multiverse amd64 Components [940 B]
2026-01-16T22:59:48.0618525Z Get:21 http://azure.archive.ubuntu.com/ubuntu noble-backports/main amd64 Components [7284 B]
2026-01-16T22:59:48.0629473Z Get:22 http://azure.archive.ubuntu.com/ubuntu noble-backports/universe amd64 Components [10.5 kB]
2026-01-16T22:59:48.0639714Z Get:23 http://azure.archive.ubuntu.com/ubuntu noble-backports/restricted amd64 Components [216 B]
2026-01-16T22:59:48.0651058Z Get:24 http://azure.archive.ubuntu.com/ubuntu noble-backports/multiverse amd64 Components [212 B]
2026-01-16T22:59:48.0685946Z Get:26 https://packages.microsoft.com/ubuntu/24.04/prod noble/main armhf Packages [11.4 kB]
2026-01-16T22:59:48.0730249Z Get:27 https://packages.microsoft.com/ubuntu/24.04/prod noble/main arm64 Packages [61.9 kB]
2026-01-16T22:59:48.1088552Z Get:28 http://azure.archive.ubuntu.com/ubuntu noble-security/main amd64 Packages [1404 kB]
2026-01-16T22:59:48.1169094Z Get:29 http://azure.archive.ubuntu.com/ubuntu noble-security/main Translation-en [228 kB]
2026-01-16T22:59:48.1193654Z Get:30 http://azure.archive.ubuntu.com/ubuntu noble-security/main amd64 Components [21.5 kB]
2026-01-16T22:59:48.1204620Z Get:31 http://azure.archive.ubuntu.com/ubuntu noble-security/main amd64 c-n-f Metadata [9724 B]
2026-01-16T22:59:48.1218136Z Get:32 http://azure.archive.ubuntu.com/ubuntu noble-security/universe amd64 Packages [922 kB]
2026-01-16T22:59:48.1270801Z Get:33 http://azure.archive.ubuntu.com/ubuntu noble-security/universe Translation-en [209 kB]
2026-01-16T22:59:48.1293579Z Get:34 http://azure.archive.ubuntu.com/ubuntu noble-security/universe amd64 Components [71.4 kB]
2026-01-16T22:59:48.1308254Z Get:35 http://azure.archive.ubuntu.com/ubuntu noble-security/universe amd64 c-n-f Metadata [19.7 kB]
2026-01-16T22:59:48.1757558Z Get:36 http://azure.archive.ubuntu.com/ubuntu noble-security/restricted amd64 Packages [2302 kB]
2026-01-16T22:59:48.1871843Z Get:37 http://azure.archive.ubuntu.com/ubuntu noble-security/restricted Translation-en [527 kB]
2026-01-16T22:59:48.1907046Z Get:38 http://azure.archive.ubuntu.com/ubuntu noble-security/restricted amd64 Components [212 B]
2026-01-16T22:59:48.1919107Z Get:39 http://azure.archive.ubuntu.com/ubuntu noble-security/multiverse amd64 Components [212 B]
2026-01-16T22:59:56.8742910Z Fetched 13.7 MB in 2s (8560 kB/s)
2026-01-16T22:59:57.6344786Z Reading package lists...
2026-01-16T22:59:57.6709466Z Reading package lists...
2026-01-16T22:59:57.8428880Z Building dependency tree...
2026-01-16T22:59:57.8435504Z Reading state information...
2026-01-16T22:59:58.0227397Z uidmap is already the newest version (1:4.13+dfsg1-4ubuntu3.2).
2026-01-16T22:59:58.0228159Z uidmap set to manually installed.
2026-01-16T22:59:58.0228937Z file is already the newest version (1:5.45-3build1).
2026-01-16T22:59:58.0229555Z The following NEW packages will be installed:
2026-01-16T22:59:58.0234560Z   attr bubblewrap
2026-01-16T22:59:58.0417689Z 0 upgraded, 2 newly installed, 0 to remove and 109 not upgraded.
2026-01-16T22:59:58.0418454Z Need to get 73.0 kB of archives.
2026-01-16T22:59:58.0419288Z After this operation, 272 kB of additional disk space will be used.
2026-01-16T22:59:58.0420017Z Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
2026-01-16T22:59:58.2096982Z Get:2 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 attr amd64 1:2.5.2-1build1.1 [22.8 kB]
2026-01-16T22:59:58.3574027Z Get:3 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 bubblewrap amd64 0.9.0-1ubuntu0.1 [50.2 kB]
2026-01-16T22:59:58.7013507Z Fetched 73.0 kB in 0s (178 kB/s)
2026-01-16T22:59:58.7240249Z Selecting previously unselected package attr.
2026-01-16T22:59:58.7568820Z (Reading database ... 
2026-01-16T22:59:58.7569286Z (Reading database ... 5%
2026-01-16T22:59:58.7569564Z (Reading database ... 10%
2026-01-16T22:59:58.7570072Z (Reading database ... 15%
2026-01-16T22:59:58.7570533Z (Reading database ... 20%
2026-01-16T22:59:58.7570998Z (Reading database ... 25%
2026-01-16T22:59:58.7571334Z (Reading database ... 30%
2026-01-16T22:59:58.7571668Z (Reading database ... 35%
2026-01-16T22:59:58.7572004Z (Reading database ... 40%
2026-01-16T22:59:58.7572341Z (Reading database ... 45%
2026-01-16T22:59:58.7572569Z (Reading database ... 50%
2026-01-16T22:59:58.7680263Z (Reading database ... 55%
2026-01-16T22:59:58.8787123Z (Reading database ... 60%
2026-01-16T22:59:58.9815988Z (Reading database ... 65%
2026-01-16T22:59:59.0396769Z (Reading database ... 70%
2026-01-16T22:59:59.1600234Z (Reading database ... 75%
2026-01-16T22:59:59.3349282Z (Reading database ... 80%
2026-01-16T22:59:59.4985198Z (Reading database ... 85%
2026-01-16T22:59:59.6820435Z (Reading database ... 90%
2026-01-16T22:59:59.8482276Z (Reading database ... 95%
2026-01-16T22:59:59.8482863Z (Reading database ... 100%
2026-01-16T22:59:59.8483663Z (Reading database ... 217536 files and directories currently installed.)
2026-01-16T22:59:59.8541513Z Preparing to unpack .../attr_1%3a2.5.2-1build1.1_amd64.deb ...
2026-01-16T22:59:59.8569316Z Unpacking attr (1:2.5.2-1build1.1) ...
2026-01-16T22:59:59.8828514Z Selecting previously unselected package bubblewrap.
2026-01-16T22:59:59.8963688Z Preparing to unpack .../bubblewrap_0.9.0-1ubuntu0.1_amd64.deb ...
2026-01-16T22:59:59.8973870Z Unpacking bubblewrap (0.9.0-1ubuntu0.1) ...
2026-01-16T22:59:59.9440966Z Setting up bubblewrap (0.9.0-1ubuntu0.1) ...
2026-01-16T22:59:59.9494821Z Setting up attr (1:2.5.2-1build1.1) ...
2026-01-16T22:59:59.9525323Z Processing triggers for man-db (2.12.0-4build2) ...
2026-01-16T22:59:59.9558481Z Not building database; man-db/auto-update is not 'true'.
2026-01-16T23:00:00.6252898Z 
2026-01-16T23:00:00.6253671Z Running kernel seems to be up-to-date.
2026-01-16T23:00:00.6254037Z 
2026-01-16T23:00:00.6254179Z No services need to be restarted.
2026-01-16T23:00:00.6254473Z 
2026-01-16T23:00:00.6254626Z No containers need to be restarted.
2026-01-16T23:00:00.6254904Z 
2026-01-16T23:00:00.6255097Z No user sessions are running outdated binaries.
2026-01-16T23:00:00.6255439Z 
2026-01-16T23:00:00.6255746Z No VM guests are running outdated hypervisor (qemu) binaries on this host.
2026-01-16T23:00:01.6120349Z ##[group]Run sudo usermod --add-subuids 100000-165535 --add-subgids 100000-165535 "$(whoami)"
2026-01-16T23:00:01.6121068Z [36;1msudo usermod --add-subuids 100000-165535 --add-subgids 100000-165535 "$(whoami)"[0m
2026-01-16T23:00:01.6121621Z [36;1msudo usermod --add-subuids 100000-165535 --add-subgids 100000-165535 root[0m
2026-01-16T23:00:01.6121987Z [36;1m{[0m
2026-01-16T23:00:01.6122208Z [36;1m  echo 'kernel.unprivileged_userns_clone=1'[0m
2026-01-16T23:00:01.6122577Z [36;1m  echo 'kernel.apparmor_restrict_unprivileged_userns=0'[0m
2026-01-16T23:00:01.6122960Z [36;1m} | sudo tee /etc/sysctl.d/99-unprivileged-userns.conf[0m
2026-01-16T23:00:01.6123277Z [36;1msudo sysctl --system[0m
2026-01-16T23:00:01.6156778Z shell: /usr/bin/bash -e {0}
2026-01-16T23:00:01.6157021Z env:
2026-01-16T23:00:01.6157220Z   WIZARDRY_OS_LABEL: ubuntu
2026-01-16T23:00:01.6157430Z ##[endgroup]
2026-01-16T23:00:01.6838365Z kernel.unprivileged_userns_clone=1
2026-01-16T23:00:01.6839150Z kernel.apparmor_restrict_unprivileged_userns=0
2026-01-16T23:00:01.6920383Z * Applying /usr/lib/sysctl.d/10-apparmor.conf ...
2026-01-16T23:00:01.6920925Z * Applying /etc/sysctl.d/10-bufferbloat.conf ...
2026-01-16T23:00:01.6921401Z * Applying /etc/sysctl.d/10-console-messages.conf ...
2026-01-16T23:00:01.6921942Z * Applying /etc/sysctl.d/10-ipv6-privacy.conf ...
2026-01-16T23:00:01.6922543Z * Applying /etc/sysctl.d/10-kernel-hardening.conf ...
2026-01-16T23:00:01.6922964Z * Applying /etc/sysctl.d/10-magic-sysrq.conf ...
2026-01-16T23:00:01.6923275Z * Applying /etc/sysctl.d/10-map-count.conf ...
2026-01-16T23:00:01.6923641Z * Applying /etc/sysctl.d/10-network-security.conf ...
2026-01-16T23:00:01.6923968Z * Applying /etc/sysctl.d/10-ptrace.conf ...
2026-01-16T23:00:01.6924260Z * Applying /etc/sysctl.d/10-zeropage.conf ...
2026-01-16T23:00:01.6924563Z * Applying /usr/lib/sysctl.d/50-bubblewrap.conf ...
2026-01-16T23:00:01.6924890Z * Applying /usr/lib/sysctl.d/50-coredump.conf ...
2026-01-16T23:00:01.6925207Z * Applying /usr/lib/sysctl.d/50-pid-max.conf ...
2026-01-16T23:00:01.6925526Z * Applying /etc/sysctl.d/99-cloudimg-ipv6.conf ...
2026-01-16T23:00:01.6925868Z * Applying /etc/sysctl.d/99-cloudimg-udp.conf ...
2026-01-16T23:00:01.6926508Z * Applying /usr/lib/sysctl.d/99-protect-links.conf ...
2026-01-16T23:00:01.6926814Z * Applying /etc/sysctl.d/99-sysctl.conf ...
2026-01-16T23:00:01.6927146Z * Applying /etc/sysctl.d/99-unprivileged-userns.conf ...
2026-01-16T23:00:01.6927462Z * Applying /etc/sysctl.conf ...
2026-01-16T23:00:01.6927723Z kernel.apparmor_restrict_unprivileged_userns = 1
2026-01-16T23:00:01.6928017Z net.core.default_qdisc = fq_codel
2026-01-16T23:00:01.6928248Z kernel.printk = 4 4 1 7
2026-01-16T23:00:01.6928464Z net.ipv6.conf.all.use_tempaddr = 2
2026-01-16T23:00:01.6929059Z net.ipv6.conf.default.use_tempaddr = 2
2026-01-16T23:00:01.6929317Z kernel.kptr_restrict = 1
2026-01-16T23:00:01.6929513Z kernel.sysrq = 176
2026-01-16T23:00:01.6929699Z vm.max_map_count = 1048576
2026-01-16T23:00:01.6929931Z net.ipv4.conf.default.rp_filter = 2
2026-01-16T23:00:01.6930201Z net.ipv4.conf.all.rp_filter = 2
2026-01-16T23:00:01.6930440Z kernel.yama.ptrace_scope = 1
2026-01-16T23:00:01.6930762Z vm.mmap_min_addr = 65536
2026-01-16T23:00:01.6931414Z kernel.unprivileged_userns_clone = 1
2026-01-16T23:00:01.6932264Z kernel.core_pattern = |/usr/lib/systemd/systemd-coredump %P %u %g %s %t 9223372036854775808 %h %d
2026-01-16T23:00:01.6932919Z kernel.core_pipe_limit = 16
2026-01-16T23:00:01.6933138Z fs.suid_dumpable = 2
2026-01-16T23:00:01.6933333Z kernel.pid_max = 4194304
2026-01-16T23:00:01.6933559Z net.ipv6.conf.all.use_tempaddr = 0
2026-01-16T23:00:01.6933812Z net.ipv6.conf.default.use_tempaddr = 0
2026-01-16T23:00:01.6934063Z net.core.rmem_max = 1048576
2026-01-16T23:00:01.6934274Z net.core.rmem_default = 1048576
2026-01-16T23:00:01.6934500Z fs.protected_fifos = 1
2026-01-16T23:00:01.6934702Z fs.protected_hardlinks = 1
2026-01-16T23:00:01.6934920Z fs.protected_regular = 2
2026-01-16T23:00:01.6935366Z fs.protected_symlinks = 1
2026-01-16T23:00:01.6935613Z vm.max_map_count = 262144
2026-01-16T23:00:01.6935837Z fs.inotify.max_user_watches = 655360
2026-01-16T23:00:01.6936098Z fs.inotify.max_user_instances = 1280
2026-01-16T23:00:01.6936349Z vm.mmap_rnd_bits = 28
2026-01-16T23:00:01.6936555Z kernel.unprivileged_userns_clone = 1
2026-01-16T23:00:01.6936835Z kernel.apparmor_restrict_unprivileged_userns = 0
2026-01-16T23:00:01.6937107Z vm.max_map_count = 262144
2026-01-16T23:00:01.6937319Z fs.inotify.max_user_watches = 655360
2026-01-16T23:00:01.6937546Z fs.inotify.max_user_instances = 1280
2026-01-16T23:00:01.6937771Z vm.mmap_rnd_bits = 28
2026-01-16T23:00:01.6971412Z ##[group]Run if bwrap --unshare-user-try --ro-bind / / /bin/true; then
2026-01-16T23:00:01.6971924Z [36;1mif bwrap --unshare-user-try --ro-bind / / /bin/true; then[0m
2026-01-16T23:00:01.6972307Z [36;1m  echo "bubblewrap usable with user namespaces"[0m
2026-01-16T23:00:01.6972720Z [36;1melif sudo -n bwrap --unshare-user-try --ro-bind / / /bin/true; then[0m
2026-01-16T23:00:01.6973151Z [36;1m  echo "bubblewrap usable via sudo with user namespaces"[0m
2026-01-16T23:00:01.6973507Z [36;1melif sudo -n bwrap --ro-bind / / /bin/true; then[0m
2026-01-16T23:00:01.6973828Z [36;1m  echo "bubblewrap usable via sudo"[0m
2026-01-16T23:00:01.6974072Z [36;1melse[0m
2026-01-16T23:00:01.6974347Z [36;1m  echo "bubblewrap unusable; proceeding without sandboxing" >&2[0m
2026-01-16T23:00:01.6974663Z [36;1mfi[0m
2026-01-16T23:00:01.7007515Z shell: /usr/bin/bash -e {0}
2026-01-16T23:00:01.7007739Z env:
2026-01-16T23:00:01.7007906Z   WIZARDRY_OS_LABEL: ubuntu
2026-01-16T23:00:01.7008164Z ##[endgroup]
2026-01-16T23:00:01.7088915Z bubblewrap usable with user namespaces
2026-01-16T23:00:01.7122881Z ##[group]Run . spells/.imps/sys/invoke-wizardry && banish 8 && ./spells/.wizardry/test-magic --verbose
2026-01-16T23:00:01.7123567Z [36;1m. spells/.imps/sys/invoke-wizardry && banish 8 && ./spells/.wizardry/test-magic --verbose[0m
2026-01-16T23:00:01.7156331Z shell: /usr/bin/bash -e {0}
2026-01-16T23:00:01.7156565Z env:
2026-01-16T23:00:01.7156738Z   WIZARDRY_OS_LABEL: ubuntu
2026-01-16T23:00:01.7156953Z ##[endgroup]
2026-01-16T23:01:36.7208248Z ##[error]Process completed with exit code 139.
```


### ❌ Test doppelganger compiled wizardry

```
2026-01-16T23:00:11.3679914Z [36;1mexport PATH="/tmp/wizardry-doppelganger/spells:$PATH"[0m
2026-01-16T23:00:11.3680281Z [36;1mfor dir in /tmp/wizardry-doppelganger/spells/*; do[0m
2026-01-16T23:00:11.3680593Z [36;1m  [ -d "$dir" ] && export PATH="$PATH:$dir"[0m
2026-01-16T23:00:11.3680847Z [36;1mdone[0m
2026-01-16T23:00:11.3681008Z [36;1m[0m
2026-01-16T23:00:11.3681238Z [36;1m# Use test-magic from the doppelganger (it's compiled)[0m
2026-01-16T23:00:11.3681619Z [36;1m# Add 1-hour timeout to prevent infinite hangs (e.g., test-cd)[0m
2026-01-16T23:00:11.3682055Z [36;1mif [ -x "/tmp/wizardry-doppelganger/spells/.wizardry/test-magic" ]; then[0m
2026-01-16T23:00:11.3682454Z [36;1m  timeout 3600 ./spells/.wizardry/test-magic[0m
2026-01-16T23:00:11.3682706Z [36;1melse[0m
2026-01-16T23:00:11.3682933Z [36;1m  echo "test-magic not found in doppelganger"[0m
2026-01-16T23:00:11.3683190Z [36;1m  exit 1[0m
2026-01-16T23:00:11.3683363Z [36;1mfi[0m
```


### ❌ Unit tests - Arch Linux unit tests
```
2026-01-16T22:59:58.5490889Z :: Synchronizing package databases...
2026-01-16T22:59:58.9307510Z  core downloading...
2026-01-16T22:59:58.9308165Z  extra downloading...
2026-01-16T22:59:59.1222750Z warning: procps-ng-4.0.5-3 is up to date -- reinstalling
2026-01-16T22:59:59.1223436Z resolving dependencies...
2026-01-16T22:59:59.1228081Z warning: coreutils-9.9-1 is up to date -- reinstalling
2026-01-16T22:59:59.1229400Z warning: sed-4.9-3 is up to date -- reinstalling
2026-01-16T22:59:59.1231671Z warning: gawk-5.3.2-1 is up to date -- reinstalling
2026-01-16T22:59:59.1233707Z warning: grep-3.12-2 is up to date -- reinstalling
2026-01-16T22:59:59.1234372Z warning: findutils-4.10.0-3 is up to date -- reinstalling
2026-01-16T22:59:59.1235035Z warning: attr-2.5.2-1 is up to date -- reinstalling
2026-01-16T22:59:59.1235625Z warning: file-5.46-5 is up to date -- reinstalling
2026-01-16T22:59:59.1249637Z looking for conflicting packages...
2026-01-16T22:59:59.1265050Z 
2026-01-16T22:59:59.1265634Z Package (15)          Old Version  New Version  Net Change  Download Size
2026-01-16T22:59:59.1266592Z 
2026-01-16T22:59:59.1267167Z core/db5.3                         5.3.28-5       6.45 MiB       1.18 MiB
2026-01-16T22:59:59.1267851Z core/perl                          5.42.0-1      69.88 MiB      20.40 MiB
2026-01-16T22:59:59.1268323Z extra/perl-error                   0.17030-3      0.04 MiB       0.02 MiB
2026-01-16T22:59:59.1269060Z extra/perl-mailtools               2.22-3         0.10 MiB       0.06 MiB
2026-01-16T22:59:59.1270001Z extra/perl-timedate                2.33-9         0.08 MiB       0.03 MiB
2026-01-16T22:59:59.1272056Z extra/zlib-ng                      2.3.2-1        0.28 MiB       0.11 MiB
2026-01-16T22:59:59.1272768Z core/attr             2.5.2-1      2.5.2-1        0.00 MiB       0.07 MiB
2026-01-16T22:59:59.1273475Z core/coreutils        9.9-1        9.9-1          0.00 MiB       2.78 MiB
2026-01-16T22:59:59.1274666Z core/file             5.46-5       5.46-5         0.00 MiB       0.42 MiB
2026-01-16T22:59:59.1275308Z core/findutils        4.10.0-3     4.10.0-3       0.00 MiB       0.46 MiB
2026-01-16T22:59:59.1275961Z core/gawk             5.3.2-1      5.3.2-1        0.00 MiB       1.43 MiB
2026-01-16T22:59:59.1276610Z extra/git                          2.52.0-2      29.63 MiB       6.81 MiB
2026-01-16T22:59:59.1277273Z core/grep             3.12-2       3.12-2         0.00 MiB       0.23 MiB
2026-01-16T22:59:59.1277900Z core/procps-ng        4.0.5-3      4.0.5-3        0.00 MiB       0.85 MiB
2026-01-16T22:59:59.1278582Z core/sed              4.9-3        4.9-3          0.00 MiB       0.21 MiB
2026-01-16T22:59:59.1278961Z 
2026-01-16T22:59:59.1279117Z Total Download Size:    35.07 MiB
2026-01-16T22:59:59.1279531Z Total Installed Size:  153.39 MiB
2026-01-16T22:59:59.1280173Z Net Upgrade Size:      106.46 MiB
2026-01-16T22:59:59.1280532Z 
2026-01-16T22:59:59.1281397Z :: Proceed with installation? [Y/n] 
2026-01-16T22:59:59.1281774Z :: Retrieving packages...
2026-01-16T22:59:59.3005448Z  perl-5.42.0-1-x86_64 downloading...
2026-01-16T22:59:59.3005946Z  git-2.52.0-2-x86_64 downloading...
2026-01-16T22:59:59.3006568Z  coreutils-9.9-1-x86_64 downloading...
2026-01-16T22:59:59.3006979Z  gawk-5.3.2-1-x86_64 downloading...
2026-01-16T22:59:59.3007440Z  db5.3-5.3.28-5-x86_64 downloading...
2026-01-16T22:59:59.3008212Z  procps-ng-4.0.5-3-x86_64 downloading...
2026-01-16T22:59:59.3008704Z  findutils-4.10.0-3-x86_64 downloading...
2026-01-16T22:59:59.3009149Z  file-5.46-5-x86_64 downloading...
2026-01-16T22:59:59.3009524Z  grep-3.12-2-x86_64 downloading...
2026-01-16T22:59:59.3010777Z  sed-4.9-3-x86_64 downloading...
2026-01-16T22:59:59.3011322Z  zlib-ng-2.3.2-1-x86_64 downloading...
2026-01-16T22:59:59.3011825Z  attr-2.5.2-1-x86_64 downloading...
2026-01-16T22:59:59.3012345Z  perl-mailtools-2.22-3-any downloading...
2026-01-16T22:59:59.3012966Z  perl-timedate-2.33-9-any downloading...
2026-01-16T22:59:59.3013578Z  perl-error-0.17030-3-any downloading...
2026-01-16T22:59:59.3014067Z checking keyring...
2026-01-16T22:59:59.3804232Z checking package integrity...
2026-01-16T22:59:59.7602339Z loading package files...
2026-01-16T22:59:59.7826336Z checking for file conflicts...
2026-01-16T22:59:59.7903045Z :: Processing package changes...
2026-01-16T22:59:59.7903589Z installing db5.3...
2026-01-16T22:59:59.8126938Z installing perl...
2026-01-16T23:00:00.2393992Z installing perl-error...
2026-01-16T23:00:00.2403461Z installing perl-timedate...
2026-01-16T23:00:00.2455402Z installing perl-mailtools...
2026-01-16T23:00:00.2486608Z reinstalling grep...
2026-01-16T23:00:00.2567662Z installing zlib-ng...
2026-01-16T23:00:00.2606991Z reinstalling attr...
2026-01-16T23:00:00.2712002Z reinstalling coreutils...
2026-01-16T23:00:00.3222099Z reinstalling findutils...
2026-01-16T23:00:00.3292436Z installing git...
2026-01-16T23:00:00.5019277Z Optional dependencies for git
2026-01-16T23:00:00.5020097Z     git-zsh-completion: upstream zsh completion
2026-01-16T23:00:00.5020483Z     tk: gitk and git gui
2026-01-16T23:00:00.5020749Z     openssh: ssh transport and crypto
2026-01-16T23:00:00.5021054Z     man: show help with `git command --help`
2026-01-16T23:00:00.5021325Z     perl-libwww: git svn
2026-01-16T23:00:00.5021667Z     perl-term-readkey: git svn and interactive.singlekey setting
2026-01-16T23:00:00.5022057Z     perl-io-socket-ssl: git send-email TLS support
2026-01-16T23:00:00.5022394Z     perl-authen-sasl: git send-email TLS support
2026-01-16T23:00:00.5022704Z     perl-cgi: gitweb (web interface) support
2026-01-16T23:00:00.5022995Z     python: git svn & git p4
2026-01-16T23:00:00.5023233Z     subversion: git svn
2026-01-16T23:00:00.5023545Z     org.freedesktop.secrets: keyring credential helper
2026-01-16T23:00:00.5023911Z     libsecret: libsecret credential helper [installed]
2026-01-16T23:00:00.5024234Z     less: the default pager for git
2026-01-16T23:00:00.5024494Z reinstalling procps-ng...
2026-01-16T23:00:00.5157365Z reinstalling sed...
2026-01-16T23:00:00.5208778Z reinstalling gawk...
2026-01-16T23:00:00.5390590Z reinstalling file...
2026-01-16T23:00:00.9748358Z :: Running post-transaction hooks...
2026-01-16T23:00:00.9749197Z (1/4) Creating system user accounts...
2026-01-16T23:00:01.0489884Z Creating group 'git' with GID 969.
2026-01-16T23:00:01.0495759Z Creating user 'git' (git daemon user) with UID 969 and GID 969.
2026-01-16T23:00:01.0647742Z (2/4) Reloading system manager configuration...
2026-01-16T23:00:01.1350705Z   Skipped: Current root is not booted.
2026-01-16T23:00:01.1351359Z (3/4) Arming ConditionNeedsUpdate...
2026-01-16T23:00:01.2026014Z (4/4) Checking for old perl modules...
2026-01-16T23:00:01.3497729Z ##[group]Run actions/checkout@v4
2026-01-16T23:00:01.3498015Z with:
2026-01-16T23:00:01.3498208Z   repository: andersaamodt/wizardry
2026-01-16T23:00:01.3498649Z   token: ***
2026-01-16T23:00:01.3498837Z   ssh-strict: true
2026-01-16T23:00:01.3499020Z   ssh-user: git
2026-01-16T23:00:01.3499218Z   persist-credentials: true
2026-01-16T23:00:01.3499439Z   clean: true
2026-01-16T23:00:01.3499676Z   sparse-checkout-cone-mode: true
2026-01-16T23:00:01.3500107Z   fetch-depth: 1
2026-01-16T23:00:01.3500298Z   fetch-tags: false
2026-01-16T23:00:01.3500481Z   show-progress: true
2026-01-16T23:00:01.3500679Z   lfs: false
2026-01-16T23:00:01.3500842Z   submodules: false
2026-01-16T23:00:01.3501030Z   set-safe-directory: true
2026-01-16T23:00:01.3501236Z env:
2026-01-16T23:00:01.3501395Z   WIZARDRY_OS_LABEL: arch
2026-01-16T23:00:01.3501596Z ##[endgroup]
2026-01-16T23:00:01.3543331Z ##[command]/usr/bin/docker exec  9bd097aeb3b42f0a38e4217a0f78391b2bf1f95cfbd50fec3fb1ded6c11c9708 sh -c "cat /etc/*release | grep ^ID"
2026-01-16T23:00:01.6038450Z Syncing repository: andersaamodt/wizardry
2026-01-16T23:00:01.6040187Z ##[group]Getting Git version info
2026-01-16T23:00:01.6040576Z Working directory is '/__w/wizardry/wizardry'
2026-01-16T23:00:01.6041121Z [command]/usr/sbin/git version
2026-01-16T23:00:01.6041416Z git version 2.52.0
2026-01-16T23:00:01.6042212Z ##[endgroup]
2026-01-16T23:00:01.6047084Z Temporarily overriding HOME='/__w/_temp/500432a1-7389-47bf-a0d6-7c74974793e4' before making global git config changes
2026-01-16T23:00:01.6048293Z Adding repository directory to the temporary git global config as a safe directory
2026-01-16T23:00:01.6049279Z [command]/usr/sbin/git config --global --add safe.directory /__w/wizardry/wizardry
2026-01-16T23:00:01.6058498Z Deleting the contents of '/__w/wizardry/wizardry'
2026-01-16T23:00:01.6063735Z ##[group]Initializing the repository
2026-01-16T23:00:01.6070249Z [command]/usr/sbin/git init /__w/wizardry/wizardry
2026-01-16T23:00:01.6125638Z hint: Using 'master' as the name for the initial branch. This default branch name
2026-01-16T23:00:01.6127627Z hint: will change to "main" in Git 3.0. To configure the initial branch name
2026-01-16T23:00:01.6128507Z hint: to use in all of your new repositories, which will suppress this warning,
2026-01-16T23:00:01.6129168Z hint: call:
2026-01-16T23:00:01.6129480Z hint:
2026-01-16T23:00:01.6130086Z hint: 	git config --global init.defaultBranch <name>
2026-01-16T23:00:01.6130657Z hint:
2026-01-16T23:00:01.6131171Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
2026-01-16T23:00:01.6132046Z hint: 'development'. The just-created branch can be renamed via this command:
2026-01-16T23:00:01.6132711Z hint:
2026-01-16T23:00:01.6133026Z hint: 	git branch -m <name>
2026-01-16T23:00:01.6133394Z hint:
2026-01-16T23:00:01.6133918Z hint: Disable this message with "git config set advice.defaultBranchName false"
2026-01-16T23:00:01.6134795Z Initialized empty Git repository in /__w/wizardry/wizardry/.git/
2026-01-16T23:00:01.6143350Z [command]/usr/sbin/git remote add origin https://github.com/andersaamodt/wizardry
2026-01-16T23:00:01.6189345Z ##[endgroup]
2026-01-16T23:00:01.6190238Z ##[group]Disabling automatic garbage collection
2026-01-16T23:00:01.6195185Z [command]/usr/sbin/git config --local gc.auto 0
2026-01-16T23:00:01.6239299Z ##[endgroup]
2026-01-16T23:00:01.6240130Z ##[group]Setting up auth
2026-01-16T23:00:01.6248833Z [command]/usr/sbin/git config --local --name-only --get-regexp core\.sshCommand
2026-01-16T23:00:01.6296095Z [command]/usr/sbin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
2026-01-16T23:00:01.6769126Z [command]/usr/sbin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
2026-01-16T23:00:01.6813246Z [command]/usr/sbin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
2026-01-16T23:00:01.7303993Z [command]/usr/sbin/git config --local --name-only --get-regexp ^includeIf\.gitdir:
2026-01-16T23:00:01.7361559Z [command]/usr/sbin/git submodule foreach --recursive git config --local --show-origin --name-only --get-regexp remote.origin.url
2026-01-16T23:00:01.7887958Z [command]/usr/sbin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
2026-01-16T23:00:01.7947860Z ##[endgroup]
2026-01-16T23:00:01.7948317Z ##[group]Fetching the repository
2026-01-16T23:00:01.7958615Z [command]/usr/sbin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +6883a07cb1662e42d5838f943c307bcf790bd81a:refs/remotes/pull/948/merge
2026-01-16T23:00:02.1468546Z From https://github.com/andersaamodt/wizardry
2026-01-16T23:00:02.1469428Z  * [new ref]         6883a07cb1662e42d5838f943c307bcf790bd81a -> pull/948/merge
2026-01-16T23:00:02.1521459Z ##[endgroup]
2026-01-16T23:00:02.1522863Z ##[group]Determining the checkout info
2026-01-16T23:00:02.1525072Z ##[endgroup]
2026-01-16T23:00:02.1530626Z [command]/usr/sbin/git sparse-checkout disable
2026-01-16T23:00:02.1587581Z [command]/usr/sbin/git config --local --unset-all extensions.worktreeConfig
2026-01-16T23:00:02.1631276Z ##[group]Checking out the ref
2026-01-16T23:00:02.1636033Z [command]/usr/sbin/git checkout --progress --force refs/remotes/pull/948/merge
2026-01-16T23:00:02.2119981Z Note: switching to 'refs/remotes/pull/948/merge'.
2026-01-16T23:00:02.2120448Z 
2026-01-16T23:00:02.2120768Z You are in 'detached HEAD' state. You can look around, make experimental
2026-01-16T23:00:02.2121565Z changes and commit them, and you can discard any commits you make in this
2026-01-16T23:00:02.2122367Z state without impacting any branches by switching back to a branch.
2026-01-16T23:00:02.2122888Z 
2026-01-16T23:00:02.2123181Z If you want to create a new branch to retain commits you create, you may
2026-01-16T23:00:02.2123914Z do so (now or later) by using -c with the switch command. Example:
2026-01-16T23:00:02.2124235Z 
2026-01-16T23:00:02.2124370Z   git switch -c <new-branch-name>
2026-01-16T23:00:02.2124553Z 
2026-01-16T23:00:02.2124655Z Or undo this operation with:
2026-01-16T23:00:02.2124862Z 
2026-01-16T23:00:02.2124958Z   git switch -
2026-01-16T23:00:02.2125078Z 
2026-01-16T23:00:02.2125303Z Turn off this advice by setting config variable advice.detachedHead to false
2026-01-16T23:00:02.2125636Z 
2026-01-16T23:00:02.2125992Z HEAD is now at 6883a07 Merge 9ffcb926fcb00fb9dd4d4d7f3cdaa30686588334 into 5e0c96d1ce19d7574555c371f28d26ce7e5a4392
2026-01-16T23:00:02.2132068Z ##[endgroup]
2026-01-16T23:00:02.2187322Z [command]/usr/sbin/git log -1 --format=%H
2026-01-16T23:00:02.2224837Z 6883a07cb1662e42d5838f943c307bcf790bd81a
2026-01-16T23:00:02.2398269Z ##[group]Run chmod +x spells/.arcana/mud/install-mud spells/.arcana/tor/setup-tor spells/.imps/fs/xattr-helper-usable spells/.imps/fs/xattr-list-keys spells/.imps/fs/xattr-read-value
2026-01-16T23:00:02.2399625Z [36;1mchmod +x spells/.arcana/mud/install-mud spells/.arcana/tor/setup-tor spells/.imps/fs/xattr-helper-usable spells/.imps/fs/xattr-list-keys spells/.imps/fs/xattr-read-value[0m
2026-01-16T23:00:02.2400857Z shell: sh -e {0}
2026-01-16T23:00:02.2401044Z env:
2026-01-16T23:00:02.2401446Z   WIZARDRY_OS_LABEL: arch
2026-01-16T23:00:02.2401658Z ##[endgroup]
2026-01-16T23:00:02.3111999Z ##[group]Run . spells/.imps/sys/invoke-wizardry && banish 8 && ./spells/.wizardry/test-magic --verbose
2026-01-16T23:00:02.3112728Z [36;1m. spells/.imps/sys/invoke-wizardry && banish 8 && ./spells/.wizardry/test-magic --verbose[0m
2026-01-16T23:00:02.3113271Z shell: sh -e {0}
2026-01-16T23:00:02.3113447Z env:
2026-01-16T23:00:02.3113614Z   WIZARDRY_OS_LABEL: arch
2026-01-16T23:00:02.3113814Z ##[endgroup]
2026-01-16T23:02:19.5355770Z ##[error]Process completed with exit code 139.
```


### ❌ Unit tests - Debian unit tests
```
2026-01-16T23:02:49.6878170Z === Test Summary ===
2026-01-16T23:02:49.6878384Z Total: 320/328 tests passed
2026-01-16T23:02:49.6878601Z Subtests: 1635 passed, 1664 total
2026-01-16T23:02:49.6878942Z Failed levels: 1 2 3 7 8 10
2026-01-16T23:02:50.9761020Z 
2026-01-16T23:02:50.9761544Z Extraneous test files (no corresponding spell):
2026-01-16T23:02:50.9762127Z   .tests/.imps/lex/test-parse-gloss-comprehensive.sh
2026-01-16T23:02:50.9762485Z .tests/.imps/lex/test-parse-gloss-recursion.sh
2026-01-16T23:02:50.9762791Z .tests/.imps/lex/test-parse-numeric-args.sh
2026-01-16T23:02:50.9763066Z .tests/.imps/lex/test-parse-regression.sh
2026-01-16T23:02:50.9763695Z .tests/.imps/lex/test-parse-shift-bug.sh
2026-01-16T23:02:50.9764185Z .tests/.imps/lex/test-user-reported-bugs.sh
2026-01-16T23:02:50.9764690Z .tests/.wizardry/test-custom-synonyms.sh
2026-01-16T23:02:50.9764959Z 
2026-01-16T23:02:50.9765036Z Failure Details
2026-01-16T23:02:50.9777027Z 
2026-01-16T23:02:50.9777245Z === common tests ===
2026-01-16T23:02:50.9778407Z WARNING: proceeding without sandbox isolation: bubblewrap not installed
2026-01-16T23:02:50.9786105Z FAIL #13 imps follow one-function-or-zero rule: imps violating function rule (must have 0 functions): test/detect-test-environment (has 5 functions, should be 0),
2026-01-16T23:02:50.9792276Z WARNING: spells with 2 flags (consider simplifying): priorities/prioritize(2),arcane/trash(2),spellcraft/edit-synonym(2),menu/cast(2),cantrips/list-files(2),cantrips/menu(2),.arcana/mud/toggle-all-mud(2),.wizardry/profile-tests(2),.wizardry/generate-glosses(2),.wizardry/test-magic(2),.imps/test/stub-fathom-terminal(2),.imps/test/stub-fathom-cursor(2),
2026-01-16T23:02:50.9795934Z WARNING: spells with 3 flags (strongly consider simplifying): translocation/blink(3),spellcraft/scribe-spell(3),spellcraft/lint-magic(3),wards/banish(3),.imps/menu/fathom-terminal(3),.imps/menu/fathom-cursor(3),
2026-01-16T23:02:50.9798809Z WARNING: spells with 2 positional arguments (consider simplifying): translocation/open-portal(2),spellcraft/add-synonym(2),mud/damage-file(2),menu/spell-menu(2),cantrips/ask-number(2),cantrips/move(2),.arcana/core/manage-system-command(2),.wizardry/spellbook-store(2),
2026-01-16T23:02:50.9801259Z WARNING: spells with 3 positional arguments (strongly consider simplifying): spellcraft/edit-synonym(3),system/config(3),
2026-01-16T23:02:50.9842510Z 
2026-01-16T23:02:50.9842685Z === banish ===
2026-01-16T23:02:50.9848538Z FAIL #15 banish is preloaded by invoke-wizardry
2026-01-16T23:02:50.9851921Z FAIL #23 banish checks environment variables
2026-01-16T23:02:50.9894409Z 
2026-01-16T23:02:50.9894586Z === invoke-wizardry ===
2026-01-16T23:02:50.9899369Z FAIL #7 invoke-wizardry works in non-bash shells via default path: expected status 0 but got 1
2026-01-16T23:02:50.9938078Z 
2026-01-16T23:02:50.9938274Z === generate-glosses ===
2026-01-16T23:02:50.9942871Z FAIL #7 generate-glosses hard fails on invalid default synonyms: expected status 0 but got 1
2026-01-16T23:02:50.9944215Z FAIL #8 synonym multi-word invocations work (leap to location): expected status 0 but got 1
2026-01-16T23:02:50.9983074Z 
2026-01-16T23:02:50.9984123Z === jump-to-marker ===
2026-01-16T23:02:50.9991177Z FAIL #14 jump to marker via gloss: expected status 0 but got 1; stderr: sh: 9: jump: not found
2026-01-16T23:02:50.9992155Z FAIL #15 jump via synonym: expected status 0 but got 1; stderr: sh: 9: jump: not found
2026-01-16T23:02:51.0029968Z 
2026-01-16T23:02:51.0030168Z === install-checkbashisms ===
2026-01-16T23:02:51.0031968Z FAIL #1 install-checkbashisms exits when tool is present: output missing substring: checkbashisms is already installed.
2026-01-16T23:02:51.0070273Z 
2026-01-16T23:02:51.0070517Z === format-duration ===
2026-01-16T23:02:51.0071863Z /__w/wizardry/wizardry/.tests/.imps/fmt/test-format-duration.sh: 10: assert_equals: not found
2026-01-16T23:02:51.0072684Z FAIL #1 seconds only
2026-01-16T23:02:51.0073543Z /__w/wizardry/wizardry/.tests/.imps/fmt/test-format-duration.sh: 15: assert_equals: not found
2026-01-16T23:02:51.0074335Z FAIL #2 minutes and seconds
2026-01-16T23:02:51.0075186Z /__w/wizardry/wizardry/.tests/.imps/fmt/test-format-duration.sh: 20: assert_equals: not found
2026-01-16T23:02:51.0076001Z FAIL #3 hours minutes seconds
2026-01-16T23:02:51.0077363Z /__w/wizardry/wizardry/.tests/.imps/fmt/test-format-duration.sh: 25: assert_equals: not found
2026-01-16T23:02:51.0078179Z FAIL #4 days hours minutes seconds
2026-01-16T23:02:51.0079125Z /__w/wizardry/wizardry/.tests/.imps/fmt/test-format-duration.sh: 30: assert_equals: not found
2026-01-16T23:02:51.0079906Z FAIL #5 exact minute
2026-01-16T23:02:51.0080599Z /__w/wizardry/wizardry/.tests/.imps/fmt/test-format-duration.sh: 35: assert_equals: not found
2026-01-16T23:02:51.0081479Z FAIL #6 exact hour
2026-01-16T23:02:51.0082104Z /__w/wizardry/wizardry/.tests/.imps/fmt/test-format-duration.sh: 40: assert_equals: not found
2026-01-16T23:02:51.0082870Z FAIL #7 zero seconds
2026-01-16T23:02:51.0083899Z /__w/wizardry/wizardry/.tests/.imps/fmt/test-format-duration.sh: 45: assert_equals: not found
2026-01-16T23:02:51.0084644Z FAIL #8 large duration
2026-01-16T23:02:51.0122408Z 
2026-01-16T23:02:51.0122580Z === file-to-folder ===
2026-01-16T23:02:51.0128018Z FAIL #11 file-to-folder transfers priority attribute
2026-01-16T23:02:51.0131014Z FAIL #12 file-to-folder updates parent priorities list: expected status 0 but got 1; stderr: read-magic: attribute does not exist.
2026-01-16T23:02:51.0132028Z 
2026-01-16T23:02:51.0132950Z Failed tests (debian): common-tests, banish, sys/invoke-wizardry, generate-glosses, jump-to-marker, install-checkbashisms, fmt/format-duration, file-to-folder
```


### ❌ Unit tests - Nix unit tests
```
2026-01-16T23:00:06.7429996Z * Applying /etc/sysctl.d/10-bufferbloat.conf ...
2026-01-16T23:00:06.7430540Z * Applying /etc/sysctl.d/10-console-messages.conf ...
2026-01-16T23:00:06.7431268Z * Applying /etc/sysctl.d/10-ipv6-privacy.conf ...
2026-01-16T23:00:06.7431820Z * Applying /etc/sysctl.d/10-kernel-hardening.conf ...
2026-01-16T23:00:06.7432369Z * Applying /etc/sysctl.d/10-magic-sysrq.conf ...
2026-01-16T23:00:06.7432896Z * Applying /etc/sysctl.d/10-map-count.conf ...
2026-01-16T23:00:06.7433468Z * Applying /etc/sysctl.d/10-network-security.conf ...
2026-01-16T23:00:06.7434038Z * Applying /etc/sysctl.d/10-ptrace.conf ...
2026-01-16T23:00:06.7434543Z * Applying /etc/sysctl.d/10-zeropage.conf ...
2026-01-16T23:00:06.7435082Z * Applying /usr/lib/sysctl.d/50-coredump.conf ...
2026-01-16T23:00:06.7435617Z * Applying /usr/lib/sysctl.d/50-pid-max.conf ...
2026-01-16T23:00:06.7436151Z * Applying /etc/sysctl.d/99-cloudimg-ipv6.conf ...
2026-01-16T23:00:06.7436692Z * Applying /etc/sysctl.d/99-cloudimg-udp.conf ...
2026-01-16T23:00:06.7437250Z * Applying /usr/lib/sysctl.d/99-protect-links.conf ...
2026-01-16T23:00:06.7437783Z * Applying /etc/sysctl.d/99-sysctl.conf ...
2026-01-16T23:00:06.7438326Z * Applying /etc/sysctl.d/99-unprivileged-userns.conf ...
2026-01-16T23:00:06.7438851Z * Applying /etc/sysctl.conf ...
2026-01-16T23:00:06.7439308Z kernel.apparmor_restrict_unprivileged_userns = 1
2026-01-16T23:00:06.7439803Z net.core.default_qdisc = fq_codel
2026-01-16T23:00:06.7440203Z kernel.printk = 4 4 1 7
2026-01-16T23:00:06.7440559Z net.ipv6.conf.all.use_tempaddr = 2
2026-01-16T23:00:06.7442098Z net.ipv6.conf.default.use_tempaddr = 2
2026-01-16T23:00:06.7442379Z kernel.kptr_restrict = 1
2026-01-16T23:00:06.7442586Z kernel.sysrq = 176
2026-01-16T23:00:06.7442784Z vm.max_map_count = 1048576
2026-01-16T23:00:06.7443004Z net.ipv4.conf.default.rp_filter = 2
2026-01-16T23:00:06.7443269Z net.ipv4.conf.all.rp_filter = 2
2026-01-16T23:00:06.7443539Z kernel.yama.ptrace_scope = 1
2026-01-16T23:00:06.7443924Z vm.mmap_min_addr = 65536
2026-01-16T23:00:06.7444577Z kernel.core_pattern = |/usr/lib/systemd/systemd-coredump %P %u %g %s %t 9223372036854775808 %h %d
2026-01-16T23:00:06.7445325Z kernel.core_pipe_limit = 16
2026-01-16T23:00:06.7445561Z fs.suid_dumpable = 2
2026-01-16T23:00:06.7445758Z kernel.pid_max = 4194304
2026-01-16T23:00:06.7445978Z net.ipv6.conf.all.use_tempaddr = 0
2026-01-16T23:00:06.7446229Z net.ipv6.conf.default.use_tempaddr = 0
2026-01-16T23:00:06.7446478Z net.core.rmem_max = 1048576
2026-01-16T23:00:06.7446700Z net.core.rmem_default = 1048576
2026-01-16T23:00:06.7446931Z fs.protected_fifos = 1
2026-01-16T23:00:06.7447133Z fs.protected_hardlinks = 1
2026-01-16T23:00:06.7447344Z fs.protected_regular = 2
2026-01-16T23:00:06.7447733Z fs.protected_symlinks = 1
2026-01-16T23:00:06.7447948Z vm.max_map_count = 262144
2026-01-16T23:00:06.7448160Z fs.inotify.max_user_watches = 655360
2026-01-16T23:00:06.7448399Z fs.inotify.max_user_instances = 1280
2026-01-16T23:00:06.7448630Z vm.mmap_rnd_bits = 28
2026-01-16T23:00:06.7448832Z kernel.unprivileged_userns_clone = 1
2026-01-16T23:00:06.7449110Z kernel.apparmor_restrict_unprivileged_userns = 0
2026-01-16T23:00:06.7449383Z vm.max_map_count = 262144
2026-01-16T23:00:06.7449596Z fs.inotify.max_user_watches = 655360
2026-01-16T23:00:06.7449836Z fs.inotify.max_user_instances = 1280
2026-01-16T23:00:06.7450077Z vm.mmap_rnd_bits = 28
2026-01-16T23:00:06.7473529Z ##[group]Run nix-shell -I nixpkgs=channel:nixos-unstable -p bubblewrap shadow attr --run "
2026-01-16T23:00:06.7474144Z [36;1mnix-shell -I nixpkgs=channel:nixos-unstable -p bubblewrap shadow attr --run "[0m
2026-01-16T23:00:06.7474730Z [36;1m  . spells/.imps/sys/invoke-wizardry && banish 8 && ./spells/.wizardry/test-magic --verbose[0m
2026-01-16T23:00:06.7475139Z [36;1m"[0m
2026-01-16T23:00:06.7505825Z shell: /usr/bin/bash -e {0}
2026-01-16T23:00:06.7506048Z env:
2026-01-16T23:00:06.7506212Z   WIZARDRY_OS_LABEL: nixos
2026-01-16T23:00:06.7506433Z   TMPDIR: /home/runner/work/_temp
2026-01-16T23:00:06.7506740Z   NIX_PATH: nixpkgs=/home/runner/.nix-defexpr/channels/nixpkgs
2026-01-16T23:00:06.7507051Z ##[endgroup]
2026-01-16T23:00:32.8929449Z these 67 paths will be fetched (87.74 MiB download, 412.12 MiB unpacked):
2026-01-16T23:00:32.8930166Z   /nix/store/42hsdp2wh69pclsi2flbarql4fls0sm8-acl-2.3.2
2026-01-16T23:00:32.8930957Z   /nix/store/6lnqmp6z002x7i7if04a8y7y4v29pv2k-attr-2.5.2
2026-01-16T23:00:32.8931672Z   /nix/store/gmba3r5m9sc2chvf325l7ark2y4mq38q-attr-2.5.2-bin
2026-01-16T23:00:32.8932225Z   /nix/store/pikixlr5ry2q6lnah1lxyyzrrwnsvwqv-attr-2.5.2-dev
2026-01-16T23:00:32.8932938Z   /nix/store/apyn9714vkl1wzsyhppd88agn4bmahzy-audit-4.1.2-unstable-2025-09-06-lib
2026-01-16T23:00:32.8933609Z   /nix/store/lw117lsr8d585xs63kx5k233impyrq7q-bash-5.3p3
2026-01-16T23:00:32.8934184Z   /nix/store/hkbylipx1iiawqdcjv858p501wv81bpm-bash-interactive-5.3p3
2026-01-16T23:00:32.8934771Z   /nix/store/cl88v2m1y5q3k6jlkq5jjf73nmfgl1px-binutils-2.44
2026-01-16T23:00:32.8935467Z   /nix/store/in5vxpbk3gb2acanwxmid5530pdx0n9h-binutils-2.44-lib
2026-01-16T23:00:32.8936168Z   /nix/store/dwiyp91lmxq864plaas14jm14m87sg3f-binutils-wrapper-2.44
2026-01-16T23:00:32.8936932Z   /nix/store/csk28n2yj6pzwkslf3mn2gdxz33xxazr-bubblewrap-0.11.0
2026-01-16T23:00:32.8937679Z   /nix/store/a806cxkfh97ss5c5ci99p1xpqvrpjvpa-bubblewrap-0.11.0-dev
2026-01-16T23:00:32.8938405Z   /nix/store/0c22zivvf0yspdvr2960rvmjgiwwi5wm-bzip2-1.0.8
2026-01-16T23:00:32.8939079Z   /nix/store/p61ba9fdgx3358bpp18hv4rslf6n5bq6-bzip2-1.0.8-bin
2026-01-16T23:00:32.8939774Z   /nix/store/d75200gb22v7p0703h5jrkgg8bqydk5q-coreutils-9.8
2026-01-16T23:00:32.8940689Z   /nix/store/xp179g1xi46m1la4nk8ym5j09fcihxpv-db-4.8.30
2026-01-16T23:00:32.8941494Z   /nix/store/20zvyjvxq9x2mkp7rbnvrwjjzq2n76hh-diffutils-3.12
2026-01-16T23:00:32.8943676Z   /nix/store/1qxfap7pcf4gi03b7mzcrm846lx066m9-ed-1.22.2
2026-01-16T23:00:32.8945382Z   /nix/store/dh6la4xn39d8a1kk3bdxh2lk3029ygs8-expand-response-params
2026-01-16T23:00:32.8946111Z   /nix/store/s2k48fw3y698j4kcvmw0520m06ihv2z4-file-5.45
2026-01-16T23:00:32.8947177Z   /nix/store/wd99g2j010fdkry0ws1bhxzm52w82ssx-findutils-4.10.0
2026-01-16T23:00:32.8947840Z   /nix/store/nmxm04dhkaqg1q6hai70n9zmzb0q49a5-gawk-5.3.2
2026-01-16T23:00:32.8948458Z   /nix/store/qarrb8yfby1yyypm32vabzgxgq3w41ma-gcc-15.2.0
2026-01-16T23:00:32.8949926Z   /nix/store/xc0ga87wdclrx54qjaryahkkmkmqi9qz-gcc-15.2.0-lib
2026-01-16T23:00:32.8950996Z   /nix/store/b7kx9bkjsma9wslr1cg0316m5jy450l8-gcc-15.2.0-libgcc
2026-01-16T23:00:32.8951725Z   /nix/store/r9wbjib6xxjkyb9yvjvrkl4sq61i2lyn-gcc-wrapper-15.2.0
2026-01-16T23:00:32.8953096Z   /nix/store/j193mfi0f921y0kfs8vjc1znnr45ispv-glibc-2.40-66
2026-01-16T23:00:32.8953781Z   /nix/store/7ri1mm5y99nkr7657r77wycrvhg7z9x0-glibc-2.40-66-bin
2026-01-16T23:00:32.8954476Z   /nix/store/dj43clc5ff7jjnfmhbaj6q4q0h8kpfpm-glibc-2.40-66-dev
2026-01-16T23:00:32.8955140Z   /nix/store/4vid7vad36xyam0cd1bdq1mwy1cfcvjy-gmp-6.3.0
2026-01-16T23:00:32.8955801Z   /nix/store/ysybzx4slid45akig0q5b89afh32ar6k-gmp-with-cxx-6.3.0
2026-01-16T23:00:32.8956550Z   /nix/store/axmfg44mziw9bngfj937li7c7l39x6w1-gnu-config-2024-01-01
2026-01-16T23:00:32.8957306Z   /nix/store/qfmq7p42ak5yn389qvx7zpxkan5i4xiy-gnugrep-3.12
2026-01-16T23:00:32.8957956Z   /nix/store/mkm3my2067305hdh7rzmi10npwr7y17f-gnumake-4.4.1
2026-01-16T23:00:32.8959066Z   /nix/store/k06ssckzrzn9jjvvs4n62m6567zmbx6x-gnused-4.9
2026-01-16T23:00:32.8959991Z   /nix/store/k1lcfin159706lihwx5hhvl80dbij4jw-gnutar-1.35
2026-01-16T23:00:32.8960659Z   /nix/store/0hv4z5s3r1h4lmvn0427mlxjxgvg34nr-gzip-1.14
2026-01-16T23:00:32.8961440Z   /nix/store/j6dijl59k1jy4ih6m3dwip5r0s3zc0vf-isl-0.20
2026-01-16T23:00:32.8962112Z   /nix/store/h26jnjgx97kviq90aicnfvs6mi6gllwr-libbsd-0.12.2
2026-01-16T23:00:32.8963034Z   /nix/store/mm6518pcn7aggvsqzlag9awqacd88lm9-libcap-2.77-lib
2026-01-16T23:00:32.8963599Z   /nix/store/n16jmmckg4fpqk97542hbdvlryxray79-libcap-2.77-lib
2026-01-16T23:00:32.8964110Z   /nix/store/509kz8czryxawfg9k1bbh95nlr5nry4r-libcap-ng-0.8.5
2026-01-16T23:00:32.8964712Z   /nix/store/kywwgk85nl83mpf10av3bvm2khdlq5ib-libidn2-2.3.8
2026-01-16T23:00:32.8965329Z   /nix/store/ip890k2lh9zr9703zflls5ynsa0b8fz5-libmd-1.1.0
2026-01-16T23:00:32.8965998Z   /nix/store/bbf53l4xyayqsv9hz0imsabx1wmpqisj-libmpc-1.3.1
2026-01-16T23:00:32.8966685Z   /nix/store/9862zy8hnb7xhygn1dbs9i316ldvbjyx-libselinux-3.8.1
2026-01-16T23:00:32.8967430Z   /nix/store/hlcdbvwjlzjd2x86fxghzj1gpzplccqw-libunistring-1.4.1
2026-01-16T23:00:32.8968208Z   /nix/store/5qzr2w5n5gcgh8gp3mi8sdfh6ryypfqj-libxcrypt-4.5.2
2026-01-16T23:00:32.8968967Z   /nix/store/9snzq7f6cvxfrpy1q9yxhp55xf7xp3ma-linux-headers-6.16.7
2026-01-16T23:00:32.8969728Z   /nix/store/adcxk93kpci5li5plbfka0sciqwq9jdf-linux-pam-1.7.1
2026-01-16T23:00:32.8970401Z   /nix/store/s3cfgldjl2j2ak0yz1914hbr04cgzzg0-mpfr-4.2.2
2026-01-16T23:00:32.8971197Z   /nix/store/ddranxbikfg4jkf3n1m0a0h9qqxj1vf0-ncurses-6.5
2026-01-16T23:00:32.8971843Z   /nix/store/clrf4mjwr8xcfpvway6w34wzvqc1hry4-patch-2.8
2026-01-16T23:00:32.8972507Z   /nix/store/3vs2fr2mazafcdwyza15bfhpmccx1k7z-patchelf-0.15.2
2026-01-16T23:00:32.8972966Z   /nix/store/jggxi5a991sx5si6sv47y0l2y1nqlh0g-pcre2-10.46
2026-01-16T23:00:32.8973341Z   /nix/store/vksayvpb9qm9h32k0qqg67nclrq8sf79-readline-8.3p1
2026-01-16T23:00:32.8973740Z   /nix/store/qzmn8s3imzsjn1pahvl3qqw2lyrvp8v2-shadow-4.18.0
2026-01-16T23:00:32.8974147Z   /nix/store/kbnwbwwlk42lqvrgxs3fk9px59k6magi-shadow-4.18.0-dev
2026-01-16T23:00:32.8974551Z   /nix/store/n1k7lm072r5k3g6v6wb91d2q4sxcxddm-stdenv-linux
2026-01-16T23:00:32.8975003Z   /nix/store/n234iswy40dzhd7aw6ak0wfrbyjpvbw4-systemd-minimal-libs-258.2
2026-01-16T23:00:32.8975435Z   /nix/store/z7si23pnyyfq665i5bx05yq1295g0s6j-tcb-1.2
2026-01-16T23:00:32.8976103Z   /nix/store/9k7h0vvpnb8w4xcaypff4i76n1bsmwzz-update-autotools-gnu-config-scripts-hook
2026-01-16T23:00:32.8976673Z   /nix/store/dj62xc7d90axna889yzxd4r192vib8gj-util-linux-minimal-2.41.2-login
2026-01-16T23:00:32.8977153Z   /nix/store/6h39qxzrm4i1fhl538knvyjapcdyasfx-xgcc-15.2.0-libgcc
2026-01-16T23:00:32.8977546Z   /nix/store/b32rwnzms52mwv98hkbadpl1mamzpfvx-xz-5.8.1
2026-01-16T23:00:32.8977902Z   /nix/store/j1zc5jh0vi9sbxj09ldj4xklgm6kpf8n-xz-5.8.1-bin
2026-01-16T23:00:32.8978266Z   /nix/store/c2qsgf2832zi4n29gfkqgkjpvmbmxam6-zlib-1.3.1
2026-01-16T23:00:32.9069094Z copying path '/nix/store/axmfg44mziw9bngfj937li7c7l39x6w1-gnu-config-2024-01-01' from 'https://cache.nixos.org'...
2026-01-16T23:00:32.9079292Z copying path '/nix/store/6h39qxzrm4i1fhl538knvyjapcdyasfx-xgcc-15.2.0-libgcc' from 'https://cache.nixos.org'...
2026-01-16T23:00:32.9082726Z copying path '/nix/store/b7kx9bkjsma9wslr1cg0316m5jy450l8-gcc-15.2.0-libgcc' from 'https://cache.nixos.org'...
2026-01-16T23:00:32.9603200Z copying path '/nix/store/9snzq7f6cvxfrpy1q9yxhp55xf7xp3ma-linux-headers-6.16.7' from 'https://cache.nixos.org'...
2026-01-16T23:00:32.9604879Z copying path '/nix/store/hlcdbvwjlzjd2x86fxghzj1gpzplccqw-libunistring-1.4.1' from 'https://cache.nixos.org'...
2026-01-16T23:00:32.9613131Z copying path '/nix/store/9k7h0vvpnb8w4xcaypff4i76n1bsmwzz-update-autotools-gnu-config-scripts-hook' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.0633847Z copying path '/nix/store/kywwgk85nl83mpf10av3bvm2khdlq5ib-libidn2-2.3.8' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.0817761Z copying path '/nix/store/j193mfi0f921y0kfs8vjc1znnr45ispv-glibc-2.40-66' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.6304007Z copying path '/nix/store/6lnqmp6z002x7i7if04a8y7y4v29pv2k-attr-2.5.2' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.6305697Z copying path '/nix/store/lw117lsr8d585xs63kx5k233impyrq7q-bash-5.3p3' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.6307288Z copying path '/nix/store/0c22zivvf0yspdvr2960rvmjgiwwi5wm-bzip2-1.0.8' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.6311589Z copying path '/nix/store/1qxfap7pcf4gi03b7mzcrm846lx066m9-ed-1.22.2' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.6314140Z copying path '/nix/store/nmxm04dhkaqg1q6hai70n9zmzb0q49a5-gawk-5.3.2' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.6316499Z copying path '/nix/store/dh6la4xn39d8a1kk3bdxh2lk3029ygs8-expand-response-params' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.6320086Z copying path '/nix/store/xc0ga87wdclrx54qjaryahkkmkmqi9qz-gcc-15.2.0-lib' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.6324814Z copying path '/nix/store/7ri1mm5y99nkr7657r77wycrvhg7z9x0-glibc-2.40-66-bin' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.6330172Z copying path '/nix/store/4vid7vad36xyam0cd1bdq1mwy1cfcvjy-gmp-6.3.0' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.6331698Z copying path '/nix/store/k06ssckzrzn9jjvvs4n62m6567zmbx6x-gnused-4.9' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.6333049Z copying path '/nix/store/mkm3my2067305hdh7rzmi10npwr7y17f-gnumake-4.4.1' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.6334061Z copying path '/nix/store/509kz8czryxawfg9k1bbh95nlr5nry4r-libcap-ng-0.8.5' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.6335088Z copying path '/nix/store/n16jmmckg4fpqk97542hbdvlryxray79-libcap-2.77-lib' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.6335920Z copying path '/nix/store/mm6518pcn7aggvsqzlag9awqacd88lm9-libcap-2.77-lib' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.6336638Z copying path '/nix/store/ip890k2lh9zr9703zflls5ynsa0b8fz5-libmd-1.1.0' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.6337368Z copying path '/nix/store/5qzr2w5n5gcgh8gp3mi8sdfh6ryypfqj-libxcrypt-4.5.2' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.6561236Z copying path '/nix/store/ddranxbikfg4jkf3n1m0a0h9qqxj1vf0-ncurses-6.5' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.6763417Z copying path '/nix/store/jggxi5a991sx5si6sv47y0l2y1nqlh0g-pcre2-10.46' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.6822670Z copying path '/nix/store/b32rwnzms52mwv98hkbadpl1mamzpfvx-xz-5.8.1' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.6825737Z copying path '/nix/store/c2qsgf2832zi4n29gfkqgkjpvmbmxam6-zlib-1.3.1' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.6848463Z copying path '/nix/store/42hsdp2wh69pclsi2flbarql4fls0sm8-acl-2.3.2' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.6928599Z copying path '/nix/store/gmba3r5m9sc2chvf325l7ark2y4mq38q-attr-2.5.2-bin' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.7212888Z copying path '/nix/store/p61ba9fdgx3358bpp18hv4rslf6n5bq6-bzip2-1.0.8-bin' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.7274754Z copying path '/nix/store/j6dijl59k1jy4ih6m3dwip5r0s3zc0vf-isl-0.20' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.7343543Z copying path '/nix/store/apyn9714vkl1wzsyhppd88agn4bmahzy-audit-4.1.2-unstable-2025-09-06-lib' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.7369830Z copying path '/nix/store/clrf4mjwr8xcfpvway6w34wzvqc1hry4-patch-2.8' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.7371391Z copying path '/nix/store/s3cfgldjl2j2ak0yz1914hbr04cgzzg0-mpfr-4.2.2' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.7413167Z copying path '/nix/store/pikixlr5ry2q6lnah1lxyyzrrwnsvwqv-attr-2.5.2-dev' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.7414577Z copying path '/nix/store/h26jnjgx97kviq90aicnfvs6mi6gllwr-libbsd-0.12.2' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.7416129Z copying path '/nix/store/dj62xc7d90axna889yzxd4r192vib8gj-util-linux-minimal-2.41.2-login' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.7453272Z copying path '/nix/store/0hv4z5s3r1h4lmvn0427mlxjxgvg34nr-gzip-1.14' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.7571886Z copying path '/nix/store/s2k48fw3y698j4kcvmw0520m06ihv2z4-file-5.45' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.7586260Z copying path '/nix/store/n234iswy40dzhd7aw6ak0wfrbyjpvbw4-systemd-minimal-libs-258.2' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.7743992Z copying path '/nix/store/k1lcfin159706lihwx5hhvl80dbij4jw-gnutar-1.35' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.7772529Z copying path '/nix/store/in5vxpbk3gb2acanwxmid5530pdx0n9h-binutils-2.44-lib' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.7821933Z copying path '/nix/store/j1zc5jh0vi9sbxj09ldj4xklgm6kpf8n-xz-5.8.1-bin' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.8233419Z copying path '/nix/store/dj43clc5ff7jjnfmhbaj6q4q0h8kpfpm-glibc-2.40-66-dev' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.8399623Z copying path '/nix/store/bbf53l4xyayqsv9hz0imsabx1wmpqisj-libmpc-1.3.1' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.8530423Z copying path '/nix/store/qfmq7p42ak5yn389qvx7zpxkan5i4xiy-gnugrep-3.12' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.8533983Z copying path '/nix/store/9862zy8hnb7xhygn1dbs9i316ldvbjyx-libselinux-3.8.1' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.8864041Z copying path '/nix/store/csk28n2yj6pzwkslf3mn2gdxz33xxazr-bubblewrap-0.11.0' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.9142105Z copying path '/nix/store/a806cxkfh97ss5c5ci99p1xpqvrpjvpa-bubblewrap-0.11.0-dev' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.9688924Z copying path '/nix/store/xp179g1xi46m1la4nk8ym5j09fcihxpv-db-4.8.30' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.9693339Z copying path '/nix/store/qarrb8yfby1yyypm32vabzgxgq3w41ma-gcc-15.2.0' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.9699668Z copying path '/nix/store/cl88v2m1y5q3k6jlkq5jjf73nmfgl1px-binutils-2.44' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.9701322Z copying path '/nix/store/ysybzx4slid45akig0q5b89afh32ar6k-gmp-with-cxx-6.3.0' from 'https://cache.nixos.org'...
2026-01-16T23:00:33.9702729Z copying path '/nix/store/3vs2fr2mazafcdwyza15bfhpmccx1k7z-patchelf-0.15.2' from 'https://cache.nixos.org'...
2026-01-16T23:00:34.0244118Z copying path '/nix/store/d75200gb22v7p0703h5jrkgg8bqydk5q-coreutils-9.8' from 'https://cache.nixos.org'...
2026-01-16T23:00:34.0583698Z copying path '/nix/store/adcxk93kpci5li5plbfka0sciqwq9jdf-linux-pam-1.7.1' from 'https://cache.nixos.org'...
2026-01-16T23:00:34.0937886Z copying path '/nix/store/vksayvpb9qm9h32k0qqg67nclrq8sf79-readline-8.3p1' from 'https://cache.nixos.org'...
2026-01-16T23:00:34.3370435Z copying path '/nix/store/hkbylipx1iiawqdcjv858p501wv81bpm-bash-interactive-5.3p3' from 'https://cache.nixos.org'...
2026-01-16T23:00:34.3609822Z copying path '/nix/store/20zvyjvxq9x2mkp7rbnvrwjjzq2n76hh-diffutils-3.12' from 'https://cache.nixos.org'...
2026-01-16T23:00:34.3611949Z copying path '/nix/store/wd99g2j010fdkry0ws1bhxzm52w82ssx-findutils-4.10.0' from 'https://cache.nixos.org'...
2026-01-16T23:00:34.3818384Z copying path '/nix/store/z7si23pnyyfq665i5bx05yq1295g0s6j-tcb-1.2' from 'https://cache.nixos.org'...
2026-01-16T23:00:34.4945714Z copying path '/nix/store/dwiyp91lmxq864plaas14jm14m87sg3f-binutils-wrapper-2.44' from 'https://cache.nixos.org'...
2026-01-16T23:00:34.6845669Z copying path '/nix/store/qzmn8s3imzsjn1pahvl3qqw2lyrvp8v2-shadow-4.18.0' from 'https://cache.nixos.org'...
2026-01-16T23:00:35.0326616Z copying path '/nix/store/kbnwbwwlk42lqvrgxs3fk9px59k6magi-shadow-4.18.0-dev' from 'https://cache.nixos.org'...
2026-01-16T23:00:38.0474332Z copying path '/nix/store/r9wbjib6xxjkyb9yvjvrkl4sq61i2lyn-gcc-wrapper-15.2.0' from 'https://cache.nixos.org'...
2026-01-16T23:00:38.0529946Z copying path '/nix/store/n1k7lm072r5k3g6v6wb91d2q4sxcxddm-stdenv-linux' from 'https://cache.nixos.org'...
2026-01-16T23:03:59.1483604Z /home/runner/work/_temp/9c7156fe-8c9e-4977-a39a-13ee8224fd15.sh: line 3:  2733 Segmentation fault      (core dumped) nix-shell -I nixpkgs=channel:nixos-unstable -p bubblewrap shadow attr --run "
2026-01-16T23:03:59.1485381Z   . spells/.imps/sys/invoke-wizardry && banish 8 && ./spells/.wizardry/test-magic --verbose
2026-01-16T23:03:59.1486035Z "
2026-01-16T23:03:59.1502675Z ##[error]Process completed with exit code 139.
```


### ❌ Unit tests - macOS unit tests
```
2026-01-16T23:14:55.8632420Z === Test Summary ===
2026-01-16T23:14:55.8733820Z Total: 319/328 tests passed
2026-01-16T23:14:55.8830700Z Subtests: 1608 passed, 1664 total
2026-01-16T23:14:55.8836610Z Failed levels: 1 2 3 7 8 10
2026-01-16T23:15:06.2580530Z 
2026-01-16T23:15:06.2671060Z Extraneous test files (no corresponding spell):
2026-01-16T23:15:06.2682620Z   .tests/.imps/lex/test-parse-gloss-comprehensive.sh
2026-01-16T23:15:06.2784970Z .tests/.imps/lex/test-parse-gloss-recursion.sh
2026-01-16T23:15:06.2885950Z .tests/.imps/lex/test-parse-numeric-args.sh
2026-01-16T23:15:06.2987010Z .tests/.imps/lex/test-parse-regression.sh
2026-01-16T23:15:06.3087900Z .tests/.imps/lex/test-parse-shift-bug.sh
2026-01-16T23:15:06.3188920Z .tests/.imps/lex/test-user-reported-bugs.sh
2026-01-16T23:15:06.3290220Z .tests/.wizardry/test-custom-synonyms.sh
2026-01-16T23:15:06.3383150Z 
2026-01-16T23:15:06.3484570Z Failure Details
2026-01-16T23:15:06.3585650Z 
2026-01-16T23:15:06.3687440Z === common tests ===
2026-01-16T23:15:06.3800640Z WARNING: proceeding without sandbox isolation: bubblewrap not installed
2026-01-16T23:15:06.3903090Z FAIL #13 imps follow one-function-or-zero rule: imps violating function rule (must have 0 functions): test/detect-test-environment (has 5 functions, should be 0),
2026-01-16T23:15:06.3932820Z WARNING: spells with 2 flags (consider simplifying): arcane/trash(2),.arcana/mud/toggle-all-mud(2),menu/cast(2),spellcraft/edit-synonym(2),cantrips/list-files(2),cantrips/menu(2),.wizardry/test-magic(2),.wizardry/profile-tests(2),.wizardry/generate-glosses(2),priorities/prioritize(2),.imps/test/stub-fathom-terminal(2),.imps/test/stub-fathom-cursor(2),
2026-01-16T23:15:06.3940070Z WARNING: spells with 3 flags (strongly consider simplifying): wards/banish(3),spellcraft/lint-magic(3),spellcraft/scribe-spell(3),translocation/blink(3),.imps/menu/fathom-terminal(3),.imps/menu/fathom-cursor(3),
2026-01-16T23:15:06.3946990Z WARNING: spells with 2 positional arguments (consider simplifying): mud/damage-file(       2),.arcana/core/manage-system-command(       2),menu/spell-menu(       2),spellcraft/add-synonym(       2),cantrips/move(       2),cantrips/ask-number(       2),.wizardry/spellbook-store(       2),translocation/open-portal(       2),
2026-01-16T23:15:06.3993890Z WARNING: spells with 3 positional arguments (strongly consider simplifying): system/config(       3),spellcraft/edit-synonym(       3),
2026-01-16T23:15:06.4076720Z 
2026-01-16T23:15:06.4087660Z === banish ===
2026-01-16T23:15:06.4088140Z FAIL #2 banish basic execution
2026-01-16T23:15:06.4088530Z FAIL #3 banish auto-detects from HOME
2026-01-16T23:15:06.4089030Z FAIL #4 banish verbose mode
2026-01-16T23:15:06.4089430Z FAIL #5 banish non-verbose has output
2026-01-16T23:15:06.4089890Z FAIL #6 banish custom wizardry-dir
2026-01-16T23:15:06.4090270Z FAIL #9 banish level 0 is default
2026-01-16T23:15:06.4090680Z FAIL #10 banish explicit level 0
2026-01-16T23:15:06.4091180Z FAIL #11 banish level 1 checks menu
2026-01-16T23:15:06.4091570Z FAIL #12 banish --no-tests skips tests
2026-01-16T23:15:06.4091970Z FAIL #13 banish verbose shows levels
2026-01-16T23:15:06.4092630Z FAIL #15 banish is preloaded by invoke-wizardry
2026-01-16T23:15:06.4093120Z FAIL #16 banish shows detailed imp status
2026-01-16T23:15:06.4094030Z FAIL #17 banish function calls work in command substitution
2026-01-16T23:15:06.4096980Z FAIL #18 banish script mode uses set -eu
2026-01-16T23:15:06.4097350Z FAIL #19 banish detects imps correctly (no missing imps)
2026-01-16T23:15:06.4097680Z FAIL #20 banish eval pattern works with file fallback
2026-01-16T23:15:06.4097950Z FAIL #21 banish checks shell type
2026-01-16T23:15:06.4098190Z FAIL #22 banish checks IFS
2026-01-16T23:15:06.4098520Z FAIL #23 banish checks environment variables
2026-01-16T23:15:06.4098800Z FAIL #24 banish checks umask
2026-01-16T23:15:06.4099060Z FAIL #25 banish checks filesystem write
2026-01-16T23:15:06.4101290Z FAIL #26 banish checks symbolic links
2026-01-16T23:15:06.4101530Z FAIL #27 banish checks execute permissions
2026-01-16T23:15:06.4101770Z FAIL #28 banish checks subshells
2026-01-16T23:15:06.4102070Z FAIL #29 banish checks pipes
2026-01-16T23:15:06.4118500Z FAIL #30 banish checks redirections
2026-01-16T23:15:06.4118770Z FAIL #31 banish checks signal handling
2026-01-16T23:15:06.4119030Z FAIL #32 banish checks command substitution
2026-01-16T23:15:06.4119330Z FAIL #33 banish checks parameter expansion
2026-01-16T23:15:06.4119470Z 
2026-01-16T23:15:06.4119600Z === pluralize ===
2026-01-16T23:15:06.4119890Z FAIL #5 pluralize preserves capitalization: output missing substring: Wizards
2026-01-16T23:15:06.4120170Z 
2026-01-16T23:15:06.4120220Z === invoke-wizardry ===
2026-01-16T23:15:06.4120610Z FAIL #7 invoke-wizardry works in non-bash shells via default path: expected status 0 but got 1
2026-01-16T23:15:06.4120900Z 
2026-01-16T23:15:06.4121330Z === generate-glosses ===
2026-01-16T23:15:06.4121740Z FAIL #7 generate-glosses hard fails on invalid default synonyms: expected status 0 but got 1
2026-01-16T23:15:06.4122280Z FAIL #8 synonym multi-word invocations work (leap to location): expected status 0 but got 1
2026-01-16T23:15:06.4200350Z 
2026-01-16T23:15:06.4203290Z === jump-to-marker ===
2026-01-16T23:15:06.4217210Z FAIL #14 jump to marker via gloss: expected status 0 but got 1; stderr: sh: line 8: jump: command not found
2026-01-16T23:15:06.4222110Z FAIL #15 jump via synonym: expected status 0 but got 1; stderr: sh: line 8: jump: command not found
2026-01-16T23:15:06.4334640Z 
2026-01-16T23:15:06.4341450Z === install-checkbashisms ===
2026-01-16T23:15:06.4350060Z FAIL #1 install-checkbashisms exits when tool is present: output missing substring: checkbashisms is already installed.
2026-01-16T23:15:06.4486490Z 
2026-01-16T23:15:06.4487100Z === format-duration ===
2026-01-16T23:15:06.4488260Z /Users/runner/work/wizardry/wizardry/.tests/.imps/fmt/test-format-duration.sh: line 10: assert_equals: command not found
2026-01-16T23:15:06.4489510Z FAIL #1 seconds only
2026-01-16T23:15:06.4490630Z /Users/runner/work/wizardry/wizardry/.tests/.imps/fmt/test-format-duration.sh: line 15: assert_equals: command not found
2026-01-16T23:15:06.4491800Z FAIL #2 minutes and seconds
2026-01-16T23:15:06.4492940Z /Users/runner/work/wizardry/wizardry/.tests/.imps/fmt/test-format-duration.sh: line 20: assert_equals: command not found
2026-01-16T23:15:06.4494140Z FAIL #3 hours minutes seconds
2026-01-16T23:15:06.4495330Z /Users/runner/work/wizardry/wizardry/.tests/.imps/fmt/test-format-duration.sh: line 25: assert_equals: command not found
2026-01-16T23:15:06.4496500Z FAIL #4 days hours minutes seconds
2026-01-16T23:15:06.4497890Z /Users/runner/work/wizardry/wizardry/.tests/.imps/fmt/test-format-duration.sh: line 30: assert_equals: command not found
2026-01-16T23:15:06.4499110Z FAIL #5 exact minute
2026-01-16T23:15:06.4500150Z /Users/runner/work/wizardry/wizardry/.tests/.imps/fmt/test-format-duration.sh: line 35: assert_equals: command not found
2026-01-16T23:15:06.4501500Z FAIL #6 exact hour
2026-01-16T23:15:06.4502540Z /Users/runner/work/wizardry/wizardry/.tests/.imps/fmt/test-format-duration.sh: line 40: assert_equals: command not found
2026-01-16T23:15:06.4503840Z FAIL #7 zero seconds
2026-01-16T23:15:06.4504910Z /Users/runner/work/wizardry/wizardry/.tests/.imps/fmt/test-format-duration.sh: line 45: assert_equals: command not found
2026-01-16T23:15:06.4506080Z FAIL #8 large duration
2026-01-16T23:15:06.4626440Z 
2026-01-16T23:15:06.4626960Z === file-to-folder ===
2026-01-16T23:15:06.4629170Z FAIL #12 file-to-folder updates parent priorities list: expected status 0 but got 1; stderr: read-magic: attribute does not exist.
2026-01-16T23:15:06.4630000Z 
2026-01-16T23:15:06.4630610Z Failed tests (mac): common-tests, banish, text/pluralize, sys/invoke-wizardry, generate-glosses, jump-to-marker, install-checkbashisms, fmt/format-duration, file-to-folder
```


💡 **View detailed logs:** Check the [workflow run logs](../../actions/runs/21083481908)

<!-- test-failures-end -->